### PR TITLE
fix: emit one JSON-LD script per schema object

### DIFF
--- a/app/(marketing)/[slug]/page.tsx
+++ b/app/(marketing)/[slug]/page.tsx
@@ -44,11 +44,19 @@ export default async function MarketingSlugPage({ params }: MarketingSlugPagePro
     path: `/${page.slug}`,
     faq: page.faq,
   });
-  const safeStructuredData = JSON.stringify(structuredData).replace(/</g, '\\u003c');
-
   return (
     <>
-      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: safeStructuredData }} />
+      {/* One script per object: single-object payloads with a top-level
+          @context survive naive JSON-LD consumers that choke on arrays. */}
+      {structuredData.map((data, index) => (
+        <script
+          key={`${String(data['@type'])}-${index}`}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+          }}
+        />
+      ))}
       <ComparisonPage page={page} isLoggedIn={Boolean(session?.user)} />
     </>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -120,10 +120,17 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="antialiased min-h-screen bg-background font-sans">
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
-        />
+        {/* One script per object: single-object payloads with a top-level
+            @context survive naive JSON-LD consumers that choke on arrays. */}
+        {structuredData.map((data) => (
+          <script
+            key={String(data['@type'])}
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(data).replace(/</g, '\\u003c'),
+            }}
+          />
+        ))}
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           <svg aria-hidden="true" className="fixed h-0 w-0">
             <filter id="openframe-noise">


### PR DESCRIPTION
## Summary

The root layout renders its structured data as a single `<script type="application/ld+json">` whose payload is a **top-level JSON array** of two schema objects, and the marketing pages do the same with their generated array. Arrays are valid JSON-LD, but a lot of real-world consumers (SEO browser extensions, naive crawlers) parse the script and read `parsed["@context"]` without checking for arrays, and crash with `undefined is not an object (evaluating 'r["@context"].toLowerCase')` — we hit exactly this via a Safari extension content script injected into the app.

This splits the emission into **one script tag per schema object**, so every payload is a single object with a top-level `@context`. Equivalent for search engines (Google explicitly supports multiple JSON-LD blocks), and robust for everything else. Also escapes `<` in the root layout's payload the same way the marketing pages already did.

## Checklist

- [x] `bun run check` passes
- [x] No schema changes
- [x] No unrelated file changes
- [x] No secrets committed
- [x] No behavior change requiring docs updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)