### PR TITLE
fix: BigInt serialization 500s in video PATCH and approval decision responses

### DIFF
--- a/app/api/approvals/[requestId]/decision/route.ts
+++ b/app/api/approvals/[requestId]/decision/route.ts
@@ -157,10 +157,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
                 approver: { select: { id: true, name: true, email: true, image: true } },
               },
             },
+            // Scalar fields only: the full version row carries BigInt sizeBytes,
+            // which JSON.stringify rejects when serializing the response.
             version: {
-              include: {
+              select: {
+                id: true,
+                versionNumber: true,
+                versionLabel: true,
                 video: {
-                  include: {
+                  select: {
+                    id: true,
+                    title: true,
                     project: { select: { id: true, name: true } },
                   },
                 },

--- a/app/api/projects/[projectId]/videos/[videoId]/route.ts
+++ b/app/api/projects/[projectId]/videos/[videoId]/route.ts
@@ -191,12 +191,19 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     if (typeof description === 'string') updateData.description = description.trim() || null;
     if (position !== undefined) updateData.position = position;
 
+    // Keep the response to scalar video fields: including versions would pull
+    // in BigInt columns (sizeBytes) that JSON.stringify cannot serialize, and
+    // no caller consumes the success payload beyond these fields.
     const updatedVideo = await db.video.update({
       where: { id: videoId },
       data: updateData,
-      include: {
-        versions: { orderBy: { versionNumber: 'desc' } },
-        _count: { select: { versions: true } },
+      select: {
+        id: true,
+        title: true,
+        description: true,
+        position: true,
+        projectId: true,
+        updatedAt: true,
       },
     });
 


### PR DESCRIPTION
## Summary

Two endpoints return HTTP 500 on **every successful call**, because their success payloads include `VideoVersion` rows whose `sizeBytes` column is a `BigInt` — which `JSON.stringify` cannot serialize (`TypeError: Do not know how to serialize a BigInt`). The database write commits, then response serialization throws:

- `PATCH /api/projects/[projectId]/videos/[videoId]` included all versions in the updated-video payload. It now selects scalar video fields only, which is all any caller reads.
- `POST /api/approvals/[requestId]/decision` included the full version row in the resolved request. It now selects the scalar version fields the response and notifications actually use.

The approval one is reachable the first time any approver responds to a request: the decision commits and notifications fire, but the responding user sees a failure. Found while exercising the approval flow end-to-end against a running instance.

## Checklist

- [x] `bun run check` passes
- [x] No schema changes
- [x] No unrelated file changes
- [x] No secrets committed
- [x] Backward-compatible response shape for all existing consumers

🤖 Generated with [Claude Code](https://claude.com/claude-code)