### PR TITLE
feat: aspect-ratio-aware mosaic grid for project videos

### DIFF
--- a/app/(dashboard)/projects/[projectId]/project-content-client.tsx
+++ b/app/(dashboard)/projects/[projectId]/project-content-client.tsx
@@ -86,6 +86,28 @@ interface ProjectContentClientProps {
   directUploadProvider: DirectUploadProvider;
 }
 
+// Mosaic sizing: thumbnails report their natural aspect ratio on load and are
+// normalized into three buckets so mixed-format projects (vertical social
+// cuts, square posts, widescreen spots) tile without letterboxing. Cards
+// default to landscape until their thumbnail reports otherwise. Every card
+// derives its width from one shared media height, so rows stay aligned:
+// portrait tiles narrow, landscape tiles wide, all thumbnails equally tall.
+const PORTRAIT_ASPECT_RATIO = 9 / 16;
+const SQUARE_ASPECT_RATIO = 1;
+const LANDSCAPE_ASPECT_RATIO = 16 / 9;
+const PORTRAIT_CARD_WIDTH = 240;
+const MOSAIC_MEDIA_HEIGHT = PORTRAIT_CARD_WIDTH / PORTRAIT_ASPECT_RATIO;
+
+function normalizeMosaicAspectRatio(aspectRatio: number): number {
+  if (aspectRatio < 0.8) return PORTRAIT_ASPECT_RATIO;
+  if (aspectRatio < 1.25) return SQUARE_ASPECT_RATIO;
+  return LANDSCAPE_ASPECT_RATIO;
+}
+
+function getMosaicCardWidth(aspectRatio: number): number {
+  return Math.round(MOSAIC_MEDIA_HEIGHT * aspectRatio);
+}
+
 export function ProjectContentClient({
   project,
   projectId,
@@ -106,6 +128,15 @@ export function ProjectContentClient({
   const [localVideos, setLocalVideos] = useState<SerializedVideo[]>(videos);
   const [selectedVideoIds, setSelectedVideoIds] = useState<string[]>([]);
   const [selectionMode, setSelectionMode] = useState(false);
+  const [videoAspectRatios, setVideoAspectRatios] = useState<Record<string, number>>({});
+
+  const handleVideoAspectRatioChange = useCallback((videoId: string, aspectRatio: number) => {
+    const normalizedAspectRatio = normalizeMosaicAspectRatio(aspectRatio);
+    setVideoAspectRatios((current) => {
+      if (current[videoId] === normalizedAspectRatio) return current;
+      return { ...current, [videoId]: normalizedAspectRatio };
+    });
+  }, []);
   const [isDownloading, setIsDownloading] = useState(false);
   const [includeAssetsInDownload, setIncludeAssetsInDownload] = useState(false);
   const [isDeletingSelected, setIsDeletingSelected] = useState(false);
@@ -548,21 +579,41 @@ export function ProjectContentClient({
 
       {/* Videos Grid */}
       {localVideos.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {localVideos.map((video) => (
-            <VideoCard
-              key={video.id}
-              video={video}
-              projectId={projectId}
-              canManage={canEdit}
-              canSelect={canSelectVideos}
-              selectionMode={selectionMode}
-              selected={selectedVideoIds.includes(video.id)}
-              onEnterSelectionMode={handleEnterSelectionMode}
-              onSelectedChange={(selected) => toggleVideoSelection(video.id, selected)}
-              onDeleted={handleVideoDeleted}
-            />
-          ))}
+        <div className="flex flex-wrap items-start gap-4">
+          {localVideos.map((video) => {
+            const aspectRatio = videoAspectRatios[video.id] ?? LANDSCAPE_ASPECT_RATIO;
+            const cardWidth = getMosaicCardWidth(aspectRatio);
+
+            return (
+              <div
+                key={video.id}
+                className="min-w-0"
+                style={{
+                  flexGrow: 0,
+                  flexShrink: 1,
+                  flexBasis: `${cardWidth}px`,
+                  maxWidth: `${cardWidth}px`,
+                  minWidth: 'min(100%, 220px)',
+                }}
+              >
+                <VideoCard
+                  video={video}
+                  projectId={projectId}
+                  canManage={canEdit}
+                  canSelect={canSelectVideos}
+                  selectionMode={selectionMode}
+                  selected={selectedVideoIds.includes(video.id)}
+                  thumbnailAspectRatio={aspectRatio}
+                  onThumbnailAspectRatioChange={(nextAspectRatio) =>
+                    handleVideoAspectRatioChange(video.id, nextAspectRatio)
+                  }
+                  onEnterSelectionMode={handleEnterSelectionMode}
+                  onSelectedChange={(selected) => toggleVideoSelection(video.id, selected)}
+                  onDeleted={handleVideoDeleted}
+                />
+              </div>
+            );
+          })}
         </div>
       ) : (
         <Card className="border-dashed">

--- a/components/video-card.tsx
+++ b/components/video-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type SyntheticEvent } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
@@ -74,6 +74,8 @@ interface VideoCardProps {
   canSelect?: boolean;
   selectionMode?: boolean;
   selected?: boolean;
+  thumbnailAspectRatio?: number;
+  onThumbnailAspectRatioChange?: (aspectRatio: number) => void;
   onEnterSelectionMode?: () => void;
   onSelectedChange?: (selected: boolean) => void;
   onDeleted?: (videoId: string) => void;
@@ -86,6 +88,8 @@ export function VideoCard({
   canSelect = false,
   selectionMode = false,
   selected = false,
+  thumbnailAspectRatio = 16 / 9,
+  onThumbnailAspectRatioChange,
   onEnterSelectionMode,
   onSelectedChange,
   onDeleted,
@@ -93,6 +97,13 @@ export function VideoCard({
   const router = useRouter();
   const [imgError, setImgError] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
+
+  const handleThumbnailLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = event.currentTarget;
+    if (naturalWidth > 0 && naturalHeight > 0) {
+      onThumbnailAspectRatioChange?.(naturalWidth / naturalHeight);
+    }
+  };
 
   // Edit dialog
   const [showEditDialog, setShowEditDialog] = useState(false);
@@ -265,7 +276,10 @@ export function VideoCard({
           }
         >
           {selectionMode ? (
-            <div className="relative aspect-video bg-muted overflow-hidden">
+            <div
+              className="relative bg-muted overflow-hidden"
+              style={{ aspectRatio: thumbnailAspectRatio }}
+            >
               {imgError ? (
                 <div className="absolute inset-0 flex flex-col items-center justify-center bg-muted/80">
                   <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-2" />
@@ -279,6 +293,7 @@ export function VideoCard({
                   src={`${resolvedThumbnailUrl}${retryKey ? `?t=${retryKey}` : ''}`}
                   alt={video.title}
                   className="absolute inset-0 w-full h-full object-cover"
+                  onLoad={handleThumbnailLoad}
                   onError={() => {
                     setImgError(true);
                     setTimeout(() => {
@@ -296,7 +311,10 @@ export function VideoCard({
           ) : (
             <Link href={`/projects/${projectId}/videos/${video.id}`}>
               {/* Thumbnail */}
-              <div className="relative aspect-video bg-muted overflow-hidden">
+              <div
+                className="relative bg-muted overflow-hidden"
+                style={{ aspectRatio: thumbnailAspectRatio }}
+              >
                 {imgError ? (
                   <div className="absolute inset-0 flex flex-col items-center justify-center bg-muted/80">
                     <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-2" />
@@ -313,6 +331,7 @@ export function VideoCard({
                     src={`${resolvedThumbnailUrl}${retryKey ? `?t=${retryKey}` : ''}`}
                     alt={video.title}
                     className="absolute inset-0 w-full h-full object-cover transition-transform group-hover:scale-105"
+                    onLoad={handleThumbnailLoad}
                     onError={() => {
                       setImgError(true);
                       // Check again after 10 seconds in case Bunny is still processing


### PR DESCRIPTION
## Summary

Review projects mix formats — vertical social cuts, square posts, widescreen spots — but the project grid is a fixed three-column layout, so portrait thumbnails get letterboxed into landscape tiles and most of each cell is empty space.

This makes the grid aspect-ratio aware:

- Each card's thumbnail reports its natural aspect ratio on load (`naturalWidth / naturalHeight`)
- Ratios are normalized into three buckets — portrait (9:16), square (1:1), landscape (16:9) — so the layout stays orderly instead of jittering per-pixel
- Every card derives its width from one shared media height, so rows stay aligned: portrait cards tile narrow, landscape cards wide, and all thumbnails render equally tall
- Cards default to landscape until their thumbnail reports otherwise, so there is no layout thrash while images load

No API or schema changes — this is purely client-side layout. Cards without a loadable thumbnail keep the landscape default. Extracted from a fork where it has been running in production use; happy to add before/after screenshots or adjust the sizing to taste.

## Checklist

- [x] `bun run check` passes
- [x] No schema changes
- [x] No unrelated file changes
- [x] No secrets committed
- [x] Client-side only; no docs impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)