### PR TITLE
feat: group project videos by date added

### DIFF
--- a/app/(dashboard)/projects/[projectId]/page.tsx
+++ b/app/(dashboard)/projects/[projectId]/page.tsx
@@ -108,7 +108,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
       where: { projectId: project.id },
       skip,
       take: pageSize,
-      orderBy: [{ updatedAt: sortOrder }, { id: sortOrder }],
+      orderBy: [{ createdAt: sortOrder }, { id: sortOrder }],
       include: {
         versions: {
           where: { isActive: true },
@@ -145,8 +145,13 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
       duration: formatDuration(activeVersion?.duration),
       lastUpdated: formatRelativeTime(video.updatedAt),
       updatedAt: video.updatedAt.toISOString(),
+      createdAt: video.createdAt.toISOString(),
     };
   });
+
+  // Serialized once on the server so date-group labels ("Today", "Yesterday")
+  // are computed against a stable reference instead of client render time.
+  const timelineReferenceDate = new Date().toISOString();
 
   const directUploadsEnabled = isDirectFileUploadEnabled();
   const directUploadProvider = isS3VideoUploadsEnabled() ? 'r2' : 'bunny';
@@ -190,6 +195,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
             projectId={projectId}
             videos={videos}
             allVideoIds={allVideoIds.map((video) => video.id)}
+            timelineReferenceDate={timelineReferenceDate}
             canEdit={false}
             canDownloadProject={canDownloadProject}
             isOwner={false}
@@ -222,6 +228,7 @@ export default async function ProjectPage({ params, searchParams }: ProjectPageP
         projectId={projectId}
         videos={videos}
         allVideoIds={allVideoIds.map((video) => video.id)}
+        timelineReferenceDate={timelineReferenceDate}
         canEdit={canEdit}
         canDownloadProject={canDownloadProject}
         isOwner={isOwner}

--- a/app/(dashboard)/projects/[projectId]/project-content-client.tsx
+++ b/app/(dashboard)/projects/[projectId]/project-content-client.tsx
@@ -61,6 +61,19 @@ interface SerializedVideo {
   duration: string;
   lastUpdated: string;
   updatedAt: string;
+  createdAt: string;
+}
+
+interface VideoDateGroup {
+  key: string;
+  label: string;
+  videos: SerializedVideo[];
+}
+
+interface CalendarDateParts {
+  year: number;
+  month: number;
+  day: number;
 }
 
 interface ProjectContentClientProps {
@@ -75,6 +88,7 @@ interface ProjectContentClientProps {
   projectId: string;
   videos: SerializedVideo[];
   allVideoIds: string[];
+  timelineReferenceDate: string;
   canEdit: boolean;
   canDownloadProject: boolean;
   isOwner: boolean;
@@ -108,11 +122,94 @@ function getMosaicCardWidth(aspectRatio: number): number {
   return Math.round(MOSAIC_MEDIA_HEIGHT * aspectRatio);
 }
 
+// Calendar-day math runs through Intl with an explicit time zone so "Today"
+// and "Yesterday" follow the viewer's local calendar, not UTC boundaries.
+function getCalendarDateParts(date: Date, timeZone: string): CalendarDateParts {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+
+  const getPart = (type: Intl.DateTimeFormatPartTypes) =>
+    Number(parts.find((part) => part.type === type)?.value);
+
+  return {
+    year: getPart('year'),
+    month: getPart('month'),
+    day: getPart('day'),
+  };
+}
+
+function getCalendarDayNumber(parts: CalendarDateParts): number {
+  return Math.floor(Date.UTC(parts.year, parts.month - 1, parts.day) / 86_400_000);
+}
+
+function groupVideosByCreatedDate(
+  videos: SerializedVideo[],
+  referenceDate: Date,
+  timeZone: string
+): VideoDateGroup[] {
+  const referenceParts = getCalendarDateParts(referenceDate, timeZone);
+  const referenceDayNumber = getCalendarDayNumber(referenceParts);
+  const referenceWeekday = new Date(
+    Date.UTC(referenceParts.year, referenceParts.month - 1, referenceParts.day)
+  ).getUTCDay();
+  const weekdayFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    weekday: 'long',
+  });
+  const dateFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  });
+  const dateWithYearFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+  const groups = new Map<string, VideoDateGroup>();
+
+  for (const video of videos) {
+    const createdAt = new Date(video.createdAt);
+    const parts = getCalendarDateParts(createdAt, timeZone);
+    const key = `${parts.year}-${String(parts.month).padStart(2, '0')}-${String(parts.day).padStart(2, '0')}`;
+    const dayDifference = referenceDayNumber - getCalendarDayNumber(parts);
+
+    let label: string;
+    if (dayDifference === 0) {
+      label = 'Today';
+    } else if (dayDifference === 1) {
+      label = 'Yesterday';
+    } else if (dayDifference > 1 && dayDifference <= referenceWeekday) {
+      label = weekdayFormatter.format(createdAt);
+    } else if (parts.year === referenceParts.year) {
+      label = dateFormatter.format(createdAt);
+    } else {
+      label = dateWithYearFormatter.format(createdAt);
+    }
+
+    const existingGroup = groups.get(key);
+    if (existingGroup) {
+      existingGroup.videos.push(video);
+    } else {
+      groups.set(key, { key, label, videos: [video] });
+    }
+  }
+
+  return Array.from(groups.values());
+}
+
 export function ProjectContentClient({
   project,
   projectId,
   videos,
   allVideoIds,
+  timelineReferenceDate,
   canEdit,
   canDownloadProject,
   isOwner,
@@ -129,6 +226,19 @@ export function ProjectContentClient({
   const [selectedVideoIds, setSelectedVideoIds] = useState<string[]>([]);
   const [selectionMode, setSelectionMode] = useState(false);
   const [videoAspectRatios, setVideoAspectRatios] = useState<Record<string, number>>({});
+  // 'UTC' for the server render, then the viewer's zone after hydration —
+  // group labels may shift one frame but server and client markup stay
+  // consistent for the initial paint.
+  const [timelineTimeZone, setTimelineTimeZone] = useState('UTC');
+
+  useEffect(() => {
+    setTimelineTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC');
+  }, []);
+
+  const videoDateGroups = useMemo(
+    () => groupVideosByCreatedDate(localVideos, new Date(timelineReferenceDate), timelineTimeZone),
+    [localVideos, timelineReferenceDate, timelineTimeZone]
+  );
 
   const handleVideoAspectRatioChange = useCallback((videoId: string, aspectRatio: number) => {
     const normalizedAspectRatio = normalizeMosaicAspectRatio(aspectRatio);
@@ -579,41 +689,57 @@ export function ProjectContentClient({
 
       {/* Videos Grid */}
       {localVideos.length > 0 ? (
-        <div className="flex flex-wrap items-start gap-4">
-          {localVideos.map((video) => {
-            const aspectRatio = videoAspectRatios[video.id] ?? LANDSCAPE_ASPECT_RATIO;
-            const cardWidth = getMosaicCardWidth(aspectRatio);
-
-            return (
-              <div
-                key={video.id}
-                className="min-w-0"
-                style={{
-                  flexGrow: 0,
-                  flexShrink: 1,
-                  flexBasis: `${cardWidth}px`,
-                  maxWidth: `${cardWidth}px`,
-                  minWidth: 'min(100%, 220px)',
-                }}
-              >
-                <VideoCard
-                  video={video}
-                  projectId={projectId}
-                  canManage={canEdit}
-                  canSelect={canSelectVideos}
-                  selectionMode={selectionMode}
-                  selected={selectedVideoIds.includes(video.id)}
-                  thumbnailAspectRatio={aspectRatio}
-                  onThumbnailAspectRatioChange={(nextAspectRatio) =>
-                    handleVideoAspectRatioChange(video.id, nextAspectRatio)
-                  }
-                  onEnterSelectionMode={handleEnterSelectionMode}
-                  onSelectedChange={(selected) => toggleVideoSelection(video.id, selected)}
-                  onDeleted={handleVideoDeleted}
-                />
+        <div className="space-y-8">
+          {videoDateGroups.map((group) => (
+            <section key={group.key} aria-labelledby={`video-date-${group.key}`}>
+              <div className="sticky top-14 z-20 -mx-2 mb-3 border-b bg-background/95 px-2 py-2 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+                <div className="flex items-baseline gap-2">
+                  <h2 id={`video-date-${group.key}`} className="text-sm font-semibold">
+                    {group.label}
+                  </h2>
+                  <span className="text-xs text-muted-foreground">
+                    {group.videos.length} video{group.videos.length === 1 ? '' : 's'}
+                  </span>
+                </div>
               </div>
-            );
-          })}
+              <div className="flex flex-wrap items-start gap-4">
+                {group.videos.map((video) => {
+                  const aspectRatio = videoAspectRatios[video.id] ?? LANDSCAPE_ASPECT_RATIO;
+                  const cardWidth = getMosaicCardWidth(aspectRatio);
+
+                  return (
+                    <div
+                      key={video.id}
+                      className="min-w-0"
+                      style={{
+                        flexGrow: 0,
+                        flexShrink: 1,
+                        flexBasis: `${cardWidth}px`,
+                        maxWidth: `${cardWidth}px`,
+                        minWidth: 'min(100%, 220px)',
+                      }}
+                    >
+                      <VideoCard
+                        video={video}
+                        projectId={projectId}
+                        canManage={canEdit}
+                        canSelect={canSelectVideos}
+                        selectionMode={selectionMode}
+                        selected={selectedVideoIds.includes(video.id)}
+                        thumbnailAspectRatio={aspectRatio}
+                        onThumbnailAspectRatioChange={(nextAspectRatio) =>
+                          handleVideoAspectRatioChange(video.id, nextAspectRatio)
+                        }
+                        onEnterSelectionMode={handleEnterSelectionMode}
+                        onSelectedChange={(selected) => toggleVideoSelection(video.id, selected)}
+                        onDeleted={handleVideoDeleted}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
         </div>
       ) : (
         <Card className="border-dashed">

--- a/app/(dashboard)/projects/[projectId]/project-content-client.tsx
+++ b/app/(dashboard)/projects/[projectId]/project-content-client.tsx
@@ -86,6 +86,28 @@ interface ProjectContentClientProps {
   directUploadProvider: DirectUploadProvider;
 }
 
+// Mosaic sizing: thumbnails report their natural aspect ratio on load and are
+// normalized into three buckets so mixed-format projects (vertical social
+// cuts, square posts, widescreen spots) tile without letterboxing. Cards
+// default to landscape until their thumbnail reports otherwise. Every card
+// derives its width from one shared media height, so rows stay aligned:
+// portrait tiles narrow, landscape tiles wide, all thumbnails equally tall.
+const PORTRAIT_ASPECT_RATIO = 9 / 16;
+const SQUARE_ASPECT_RATIO = 1;
+const LANDSCAPE_ASPECT_RATIO = 16 / 9;
+const PORTRAIT_CARD_WIDTH = 240;
+const MOSAIC_MEDIA_HEIGHT = PORTRAIT_CARD_WIDTH / PORTRAIT_ASPECT_RATIO;
+
+function normalizeMosaicAspectRatio(aspectRatio: number): number {
+  if (aspectRatio < 0.8) return PORTRAIT_ASPECT_RATIO;
+  if (aspectRatio < 1.25) return SQUARE_ASPECT_RATIO;
+  return LANDSCAPE_ASPECT_RATIO;
+}
+
+function getMosaicCardWidth(aspectRatio: number): number {
+  return Math.round(MOSAIC_MEDIA_HEIGHT * aspectRatio);
+}
+
 export function ProjectContentClient({
   project,
   projectId,
@@ -106,6 +128,15 @@ export function ProjectContentClient({
   const [localVideos, setLocalVideos] = useState<SerializedVideo[]>(videos);
   const [selectedVideoIds, setSelectedVideoIds] = useState<string[]>([]);
   const [selectionMode, setSelectionMode] = useState(false);
+  const [videoAspectRatios, setVideoAspectRatios] = useState<Record<string, number>>({});
+
+  const handleVideoAspectRatioChange = useCallback((videoId: string, aspectRatio: number) => {
+    const normalizedAspectRatio = normalizeMosaicAspectRatio(aspectRatio);
+    setVideoAspectRatios((current) => {
+      if (current[videoId] === normalizedAspectRatio) return current;
+      return { ...current, [videoId]: normalizedAspectRatio };
+    });
+  }, []);
   const [isDownloading, setIsDownloading] = useState(false);
   const [includeAssetsInDownload, setIncludeAssetsInDownload] = useState(false);
   const [isDeletingSelected, setIsDeletingSelected] = useState(false);
@@ -548,21 +579,41 @@ export function ProjectContentClient({
 
       {/* Videos Grid */}
       {localVideos.length > 0 ? (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {localVideos.map((video) => (
-            <VideoCard
-              key={video.id}
-              video={video}
-              projectId={projectId}
-              canManage={canEdit}
-              canSelect={canSelectVideos}
-              selectionMode={selectionMode}
-              selected={selectedVideoIds.includes(video.id)}
-              onEnterSelectionMode={handleEnterSelectionMode}
-              onSelectedChange={(selected) => toggleVideoSelection(video.id, selected)}
-              onDeleted={handleVideoDeleted}
-            />
-          ))}
+        <div className="flex flex-wrap items-start gap-4">
+          {localVideos.map((video) => {
+            const aspectRatio = videoAspectRatios[video.id] ?? LANDSCAPE_ASPECT_RATIO;
+            const cardWidth = getMosaicCardWidth(aspectRatio);
+
+            return (
+              <div
+                key={video.id}
+                className="min-w-0"
+                style={{
+                  flexGrow: 0,
+                  flexShrink: 1,
+                  flexBasis: `${cardWidth}px`,
+                  maxWidth: `${cardWidth}px`,
+                  minWidth: 'min(100%, 220px)',
+                }}
+              >
+                <VideoCard
+                  video={video}
+                  projectId={projectId}
+                  canManage={canEdit}
+                  canSelect={canSelectVideos}
+                  selectionMode={selectionMode}
+                  selected={selectedVideoIds.includes(video.id)}
+                  thumbnailAspectRatio={aspectRatio}
+                  onThumbnailAspectRatioChange={(nextAspectRatio) =>
+                    handleVideoAspectRatioChange(video.id, nextAspectRatio)
+                  }
+                  onEnterSelectionMode={handleEnterSelectionMode}
+                  onSelectedChange={(selected) => toggleVideoSelection(video.id, selected)}
+                  onDeleted={handleVideoDeleted}
+                />
+              </div>
+            );
+          })}
         </div>
       ) : (
         <Card className="border-dashed">

--- a/components/video-card.tsx
+++ b/components/video-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, type SyntheticEvent } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
@@ -74,6 +74,8 @@ interface VideoCardProps {
   canSelect?: boolean;
   selectionMode?: boolean;
   selected?: boolean;
+  thumbnailAspectRatio?: number;
+  onThumbnailAspectRatioChange?: (aspectRatio: number) => void;
   onEnterSelectionMode?: () => void;
   onSelectedChange?: (selected: boolean) => void;
   onDeleted?: (videoId: string) => void;
@@ -86,6 +88,8 @@ export function VideoCard({
   canSelect = false,
   selectionMode = false,
   selected = false,
+  thumbnailAspectRatio = 16 / 9,
+  onThumbnailAspectRatioChange,
   onEnterSelectionMode,
   onSelectedChange,
   onDeleted,
@@ -93,6 +97,13 @@ export function VideoCard({
   const router = useRouter();
   const [imgError, setImgError] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
+
+  const handleThumbnailLoad = (event: SyntheticEvent<HTMLImageElement>) => {
+    const { naturalWidth, naturalHeight } = event.currentTarget;
+    if (naturalWidth > 0 && naturalHeight > 0) {
+      onThumbnailAspectRatioChange?.(naturalWidth / naturalHeight);
+    }
+  };
 
   // Edit dialog
   const [showEditDialog, setShowEditDialog] = useState(false);
@@ -265,7 +276,10 @@ export function VideoCard({
           }
         >
           {selectionMode ? (
-            <div className="relative aspect-video bg-muted overflow-hidden">
+            <div
+              className="relative bg-muted overflow-hidden"
+              style={{ aspectRatio: thumbnailAspectRatio }}
+            >
               {imgError ? (
                 <div className="absolute inset-0 flex flex-col items-center justify-center bg-muted/80">
                   <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-2" />
@@ -279,6 +293,7 @@ export function VideoCard({
                   src={`${resolvedThumbnailUrl}${retryKey ? `?t=${retryKey}` : ''}`}
                   alt={video.title}
                   className="absolute inset-0 w-full h-full object-cover"
+                  onLoad={handleThumbnailLoad}
                   onError={() => {
                     setImgError(true);
                     setTimeout(() => {
@@ -296,7 +311,10 @@ export function VideoCard({
           ) : (
             <Link href={`/projects/${projectId}/videos/${video.id}`}>
               {/* Thumbnail */}
-              <div className="relative aspect-video bg-muted overflow-hidden">
+              <div
+                className="relative bg-muted overflow-hidden"
+                style={{ aspectRatio: thumbnailAspectRatio }}
+              >
                 {imgError ? (
                   <div className="absolute inset-0 flex flex-col items-center justify-center bg-muted/80">
                     <Loader2 className="h-8 w-8 animate-spin text-muted-foreground mb-2" />
@@ -313,6 +331,7 @@ export function VideoCard({
                     src={`${resolvedThumbnailUrl}${retryKey ? `?t=${retryKey}` : ''}`}
                     alt={video.title}
                     className="absolute inset-0 w-full h-full object-cover transition-transform group-hover:scale-105"
+                    onLoad={handleThumbnailLoad}
                     onError={() => {
                       setImgError(true);
                       // Check again after 10 seconds in case Bunny is still processing


### PR DESCRIPTION
> **Stacked on #28** — this branch includes the aspect-ratio grid commit because both features reshape the same grid render. Review the last commit only; I'll rebase and mark ready once #28 lands.

## Summary

Project pages accumulate dozens of cuts, and the flat grid gives no sense of when work arrived. This groups videos under sticky calendar-day headers — **Today**, **Yesterday**, weekday names within the current week, then short dates — each with a per-group video count.

Implementation notes:

- Listing order switches to `createdAt` (from `updatedAt`) so groups stay contiguous; the existing asc/desc sort toggle still applies
- Day boundaries follow the viewer's time zone via `Intl.DateTimeFormat`, resolved after hydration (`'UTC'` during SSR keeps server and client markup consistent for the initial paint)
- The "now" reference for labels is serialized once on the server, so labels don't drift with client render time
- No API or schema changes; `createdAt` already exists on videos and is now serialized to the client

## Checklist

- [x] `bun run check` passes
- [x] No schema changes
- [x] No unrelated file changes (beyond the #28 dependency noted above)
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)