### PR TITLE
fix: audio asset playback and orphan-cleanup thumbnail deletion

### DIFF
--- a/app/api/upload/audio/[filename]/route.ts
+++ b/app/api/upload/audio/[filename]/route.ts
@@ -39,38 +39,50 @@ export async function GET(
     // Parallelize the DB lookup and session check to narrow the timing delta
     // between "asset not found" and "asset found, access denied" responses.
     const voiceUrl = `/api/upload/audio/${filename}`;
-    const [comment, session] = await Promise.all([
-      db.comment.findFirst({
+    const projectSelect = {
+      id: true,
+      ownerId: true,
+      workspaceId: true,
+      visibility: true,
+    } as const;
+    const videoSelect = {
+      id: true,
+      projectId: true,
+      project: { select: projectSelect },
+    } as const;
+    const [comments, videoAssets, session] = await Promise.all([
+      db.comment.findMany({
         where: { voiceUrl },
+        take: 2,
         select: {
           version: {
-            select: {
-              video: {
-                select: {
-                  id: true,
-                  projectId: true,
-                  project: {
-                    select: {
-                      id: true,
-                      ownerId: true,
-                      workspaceId: true,
-                      visibility: true,
-                    },
-                  },
-                },
-              },
-            },
+            select: { video: { select: videoSelect } },
           },
         },
+      }),
+      db.videoAsset.findMany({
+        where: { sourceUrl: voiceUrl },
+        take: 2,
+        select: { video: { select: videoSelect } },
       }),
       auth(),
     ]);
 
-    if (!comment) {
+    const uniqueVideos = new Map<string, (typeof videoAssets)[number]['video']>();
+    comments.forEach((comment) => {
+      if (comment.version?.video) uniqueVideos.set(comment.version.video.id, comment.version.video);
+    });
+    videoAssets.forEach((videoAsset) => uniqueVideos.set(videoAsset.video.id, videoAsset.video));
+
+    if (uniqueVideos.size > 1) {
       return apiErrors.forbidden('Access denied');
     }
 
-    const { video } = comment.version;
+    const video = uniqueVideos.values().next().value ?? null;
+    if (!video) {
+      return apiErrors.forbidden('Access denied');
+    }
+
     const access = await checkProjectAccess(video.project, session?.user?.id);
 
     if (!access.hasAccess) {

--- a/scripts/r2-orphan-cleanup.ts
+++ b/scripts/r2-orphan-cleanup.ts
@@ -119,8 +119,10 @@ async function findReferencedUrls(urls: string[]): Promise<Set<string>> {
             })
           : Promise.resolve([] as Array<{ url: string }>),
         db.videoAsset.findMany({
-          where: { sourceUrl: { in: group } },
-          select: { sourceUrl: true },
+          where: {
+            OR: [{ sourceUrl: { in: group } }, { thumbnailUrl: { in: group } }],
+          },
+          select: { sourceUrl: true, thumbnailUrl: true },
         }),
         db.videoVersion.findMany({
           where: {
@@ -142,6 +144,7 @@ async function findReferencedUrls(urls: string[]): Promise<Set<string>> {
     }
     for (const row of assetRows) {
       if (row.sourceUrl) referenced.add(row.sourceUrl);
+      if (row.thumbnailUrl) referenced.add(row.thumbnailUrl);
     }
     for (const row of versionRows) {
       if (row.originalUrl) referenced.add(row.originalUrl);


### PR DESCRIPTION
## Summary

Two R2 asset bugs that break the Assets pane's audio and video assets:

**Audio assets can never play.** The audio proxy (`/api/upload/audio/[filename]`) resolves ownership only through voice comments (`comment.voiceUrl`). `R2_AUDIO` video assets store that same proxy path in `videoAsset.sourceUrl` and are never looked up, so the route 403s for every audio asset — upload an audio asset via the Assets pane and its player 403s. Fixed by also querying `videoAsset.sourceUrl` and merging both sources into the unique-owning-video map the image proxy (`/api/upload/image/[filename]`) already uses: deny if two distinct videos claim the same file, otherwise run the usual `checkProjectAccess` + share-link fallback.

**Orphan cleanup deletes video-asset thumbnails.** `findReferencedUrls` in `scripts/r2-orphan-cleanup.ts` marks `videoAsset.sourceUrl` as referenced but not `videoAsset.thumbnailUrl`. An `R2_VIDEO` asset's generated thumbnail (`images/<uuid>.jpg`) is referenced only by that column, so run r2-orphan-cleanup with a video asset older than 15 minutes and its thumbnail is deleted. (`R2_IMAGE` assets only survived because their `thumbnailUrl` equals `sourceUrl`.) Fixed by widening the query to `OR` both columns and adding `thumbnailUrl` values to the referenced set.

Changes:

- `app/api/upload/audio/[filename]/route.ts`: mirror the image proxy's ownership resolution — shared `projectSelect`/`videoSelect` consts, `findMany` with `take: 2` over comments and video assets, unique-video map with an ambiguity guard.
- `scripts/r2-orphan-cleanup.ts`: treat `videoAsset.thumbnailUrl` as a reference alongside `sourceUrl`.

## Checklist

- [x] `bun run check` passes
- [x] No schema changes
- [x] No unrelated file changes
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
