### PR TITLE
fix(api): serialize BigInt in all API success responses

### DIFF
--- a/app/api/projects/[projectId]/videos/[videoId]/versions/route.ts
+++ b/app/api/projects/[projectId]/videos/[videoId]/versions/route.ts
@@ -2,7 +2,6 @@ import { NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { auth, checkProjectAccess } from '@/lib/auth';
 import { validateUrl, validateOptionalUrlOrAppPath } from '@/lib/validation';
-import { toJsonSafe } from '@/lib/json-serialize';
 import { rateLimit } from '@/lib/rate-limit';
 import { notifyProjectOwner } from '@/lib/notifications';
 import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
@@ -264,7 +263,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }).catch((err) => logError('Notification failed:', err));
     }
 
-    const response = successResponse(toJsonSafe(version), 201);
+    const response = successResponse(version, 201);
     return withCacheControl(response, 'private, no-store');
   } catch (error) {
     logError('Error creating version:', error);

--- a/app/api/projects/[projectId]/videos/route.ts
+++ b/app/api/projects/[projectId]/videos/route.ts
@@ -2,7 +2,6 @@ import { NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { auth, checkProjectAccess } from '@/lib/auth';
 import { validateUrl, validateOptionalUrlOrAppPath } from '@/lib/validation';
-import { toJsonSafe } from '@/lib/json-serialize';
 import { rateLimit } from '@/lib/rate-limit';
 import { notifyProjectOwner } from '@/lib/notifications';
 import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
@@ -269,7 +268,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }).catch((err) => logError('Notification failed:', err));
     }
 
-    const response = successResponse(toJsonSafe(video), 201);
+    const response = successResponse(video, 201);
     return withCacheControl(response, 'private, no-store');
   } catch (error) {
     logError('Error creating video:', error);

--- a/lib/api-response.ts
+++ b/lib/api-response.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { bigIntReplacer } from '@/lib/json-serialize';
 
 /**
  * Standardized API error response format
@@ -113,6 +114,11 @@ export function errorResponse(
  * @param status - HTTP status code (default: 200)
  * @param meta - Pagination or other metadata (optional)
  *
+ * Serialized with bigIntReplacer rather than NextResponse.json(), because
+ * JSON.stringify throws on BigInt and Prisma returns BigInt for sizeBytes.
+ * Any payload carrying a VideoVersion or VideoAsset row would otherwise 500
+ * after its write had already committed. BigInt values render as strings.
+ *
  * @example
  * ```ts
  * return successResponse({ projects: [] });
@@ -127,7 +133,10 @@ export function successResponse<T>(
   const body: ApiSuccessResponse<T> = { data };
   if (meta) body.meta = meta;
 
-  return NextResponse.json(body, { status });
+  return new NextResponse(JSON.stringify(body, bigIntReplacer), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  }) as NextResponse<ApiSuccessResponse<T>>;
 }
 
 export function withCacheControl(response: Response, value: string): Response {

--- a/lib/json-serialize.ts
+++ b/lib/json-serialize.ts
@@ -1,8 +1,18 @@
 /**
+ * JSON.stringify replacer that renders Prisma BigInt columns (sizeBytes) as
+ * strings. Without it, JSON.stringify throws on any payload carrying one.
+ */
+export function bigIntReplacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? value.toString() : value;
+}
+
+/**
  * Converts values for JSON responses (e.g. Prisma BigInt fields).
+ *
+ * API routes do not need this — successResponse() serializes BigInt already.
+ * Use it for payloads that bypass that helper, such as data handed from a
+ * server component to a client component.
  */
 export function toJsonSafe<T>(value: T): T {
-  return JSON.parse(
-    JSON.stringify(value, (_key, val) => (typeof val === 'bigint' ? val.toString() : val))
-  ) as T;
+  return JSON.parse(JSON.stringify(value, bigIntReplacer)) as T;
 }


### PR DESCRIPTION
## Summary

Follow-up to #27, which fixed two endpoints that returned 500 on every successful call because their payloads carried `VideoVersion.sizeBytes` — a Prisma `BigInt`, which `JSON.stringify` refuses to serialize.

#27 fixed those two by narrowing their `select`. Two create routes had previously been fixed a third way, by wrapping in `toJsonSafe()`. That's two conventions for one bug, and roughly 17 routes still return rows that can carry a `BigInt` column, so the next occurrence was a matter of time.

This closes the bug class at the helper instead. `successResponse()` now serializes with a shared `bigIntReplacer` rather than `NextResponse.json()`. Every route in `app/api` goes through `successResponse` — there are zero direct `NextResponse.json` calls — so all of them are covered at once.

Changes:

- `lib/json-serialize.ts`: extract `bigIntReplacer` as the single definition of how BigInt is serialized; `toJsonSafe()` now builds on it and remains available for payloads that bypass the API helpers (e.g. server component → client component).
- `lib/api-response.ts`: `successResponse()` serializes with `bigIntReplacer`. Status, `meta`, and `content-type` are unchanged; `errorResponse()` is untouched.
- `app/api/projects/[projectId]/videos/route.ts`, `.../videos/[videoId]/versions/route.ts`: drop the now-redundant `toJsonSafe()` wrappers, which were doing a full `JSON.parse(JSON.stringify())` round trip the helper now handles.

Also incidentally fixes `GET /api/projects/[projectId]/videos/[videoId]/versions`, which returns full version rows and would have 500'd the same way. It has no client caller today, which is presumably why nobody noticed.

## Verification

Beyond `bun run check`, the helper was exercised directly to confirm the old path reproduces the crash and the new one does not:

```
OLD NextResponse.json -> THREW: JSON.stringify cannot serialize BigInt.
NEW successResponse   -> status 200
NEW content-type      -> application/json
NEW body              -> {"data":{...,"versions":[{...,"sizeBytes":"5368709120"},{...,"sizeBytes":"0"}]}}
NEW 201 + meta        -> 201 {"data":{"n":"7"},"meta":{"page":1,"total":3}}
errorResponse         -> 404 {"error":"Video not found","code":"NOT_FOUND"}
```

## Note on the response contract

BigInt fields now reach clients as strings (`"5368709120"`), which is exactly what `toJsonSafe()` already produced on the two routes that used it. Serializing as a number would silently lose precision above 2^53. No client code currently reads `sizeBytes` — `shapeAssetForViewer` already excludes it from the assets DTO — so there is no behavior change today, but anything doing arithmetic on it in future needs `Number(...)`/`BigInt(...)` first.

## Checklist

- [x] `bun run check` passes
- [x] No schema changes
- [x] No unrelated file changes
- [x] No secrets committed
- [x] Backward-compatible for all existing consumers