### PR TITLE
fix(auth): keep workspace admin permissions on public projects

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -281,9 +281,13 @@ export async function checkProjectAccess(
   const isProjectMember = !!projectMember;
   const isProjectAdmin = projectMember?.role === ProjectMemberRole.ADMIN;
 
-  const needsWorkspaceForAccess = !!userId && !isOwner && !isProjectMember && !isPublic;
-  const needsWorkspaceForActions = !!userId && !isOwner && intent !== 'view';
-  const shouldLoadWorkspaceRole = needsWorkspaceForAccess || needsWorkspaceForActions;
+  // The workspace role decides `canEdit`/`isWorkspaceMember`, not just whether the viewer
+  // gets in at all, so it has to be resolved for every signed-in non-owner. Skipping it
+  // once access was already granted some other way (public project, or an existing project
+  // membership) silently downgraded workspace admins to read-only on `intent: 'view'` —
+  // the intent pages and GET routes use to decide which actions to render.
+  // Owners pass every check on their own; resolve their role only when they mutate.
+  const shouldLoadWorkspaceRole = !!userId && (!isOwner || intent !== 'view');
 
   // Check workspace membership/role
   let workspaceRole: WorkspaceMemberRole | 'OWNER' | null = null;


### PR DESCRIPTION
## Summary

`checkProjectAccess` skipped the workspace-membership lookup whenever access was already granted some other way — a `PUBLIC` project, or an existing project membership — and only forced it for intents other than `view`:

```ts
const needsWorkspaceForAccess = !!userId && !isOwner && !isProjectMember && !isPublic;
const needsWorkspaceForActions = !!userId && !isOwner && intent !== 'view';
```

The workspace role does not only gate entry, though: it feeds `canEdit` and `isWorkspaceMember`. When the lookup is skipped, `workspaceRole` stays `null`, so `isWorkspaceAdmin` is `false` and `canEdit = isOwner || isProjectAdmin || isWorkspaceAdmin` collapses to `false`.

This PR resolves the workspace role for every signed-in non-owner. Owners already pass every check on their own, so theirs is still loaded only when they mutate.

## Why

Reported by a customer: after switching a project from private to public to share it with a client, their editor could still open the project but had no **Add Version** option.

A workspace ADMIN who is not the project owner lost `canEdit` the moment the project went public. Every page and GET route calls `checkProjectAccess` with the default `intent: 'view'`, so the effects were UI-wide:

- `Add Version` / `Edit` / `Move` / `Delete` dropdown on video cards — `app/(dashboard)/projects/[projectId]/page.tsx` gates it on `access.canEdit`
- `canManageTags`, `canResolveComments`, `canRequestApproval`, `canShareVideo` on the video page — `app/api/projects/[projectId]/videos/[videoId]/route.ts`
- `GET /api/versions/[versionId]/approvals` returned 403, since it checks `access.isWorkspaceMember`

The write endpoints themselves pass `intent: 'manage'`, which did force the lookup — so `POST .../versions` would have accepted the upload. The permission was there; only the UI to reach it was gone.

A second case had the same root cause and was not visibility-dependent: a user who is both a project `COMMENTATOR` and a workspace `ADMIN` hit the `!isProjectMember` short-circuit and was read-only in the UI on private projects too.

## Scope

What areas are affected?

- [ ] API routes
- [x] Auth / access control
- [ ] Database schema / migration
- [ ] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [x] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check → lint, prettier and tsc all clean.

Reproduced with a throwaway script that stubs @/lib/db and calls the real
checkProjectAccess. Editor = workspace ADMIN, not a project member:

before
PRIVATE  | UI  (intent=view)   canEdit=true  isWorkspaceAdmin=true
INVITE   | UI  (intent=view)   canEdit=true  isWorkspaceAdmin=true
PUBLIC   | UI  (intent=view)   canEdit=false isWorkspaceAdmin=false   <-- bug
PUBLIC   | API (intent=manage) canEdit=true  isWorkspaceAdmin=true

after
PRIVATE  | UI  (intent=view)   canEdit=true  isWorkspaceAdmin=true
INVITE   | UI  (intent=view)   canEdit=true  isWorkspaceAdmin=true
PUBLIC   | UI  (intent=view)   canEdit=true  isWorkspaceAdmin=true
PUBLIC   | API (intent=manage) canEdit=true  isWorkspaceAdmin=true

Same run with the editor as a project COMMENTATOR + workspace ADMIN is now
canEdit=true on all three visibilities, matching what the write routes allow.
```

## Breaking changes

- [x] No breaking changes
- [ ] This PR introduces a breaking change (describe below)

The UI now matches what the API already authorized; no route grants access it did not grant before. Cost is one extra `workspaceMember.findUnique`, issued in parallel with the workspace fetch that already ran, on project views by signed-in non-owners.

## Database / migration notes

None.

## Screenshots / examples (if relevant)

Not applicable — no visual changes beyond previously hidden controls reappearing.

---

Two things found while tracing this, left out of this PR:

1. There is no "editor" role. Project and workspace roles are only `ADMIN | COMMENTATOR` (`prisma/schema.prisma`). Someone invited as a Commentator genuinely cannot add versions — the API rejects it too. Worth considering a real editor role.
2. The **New Version** button on the video page (`components/video-page/video-page-header.tsx`) renders for anyone in `dashboard` mode, ungated by `canEdit`, so a Commentator sees it and gets a 403 on submit.
