### PR TITLE
feat(invitations): guide invited users without an account through sign-up

### DIFF
--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -9,17 +9,21 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { signIn } from 'next-auth/react';
+import { getSafeCallbackUrl, isInvitationCallbackUrl } from '@/lib/safe-redirect';
 
-function getSafeCallbackUrl(value: string | null): string {
-  if (!value) return '/dashboard';
-  try {
-    const baseOrigin = typeof window === 'undefined' ? 'http://localhost' : window.location.origin;
-    const parsed = new URL(value, baseOrigin);
-    if (parsed.origin !== baseOrigin) return '/dashboard';
-    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
-  } catch {
-    return '/dashboard';
+/**
+ * Sign-up link that carries the pending destination — and, when that destination is an
+ * invitation, the invitation token itself so the new account is bound to the invite.
+ */
+function buildRegisterHref(callbackUrl: string): string {
+  if (callbackUrl === '/dashboard') return '/register';
+
+  const params = new URLSearchParams({ callbackUrl });
+  if (isInvitationCallbackUrl(callbackUrl)) {
+    const token = new URLSearchParams(callbackUrl.split('?')[1] ?? '').get('token');
+    if (token) params.set('invitationToken', token);
   }
+  return `/register?${params.toString()}`;
 }
 
 const ERROR_MESSAGES: Record<string, string> = {
@@ -50,6 +54,8 @@ function LoginFormInner({ googleEnabled, githubEnabled }: LoginFormInnerProps) {
   const [showSuccess, setShowSuccess] = useState(false);
   const [showVerifiedSuccess, setShowVerifiedSuccess] = useState(false);
   const callbackUrl = getSafeCallbackUrl(searchParams.get('callbackUrl'));
+  const isInvitationFlow = isInvitationCallbackUrl(callbackUrl);
+  const registerHref = buildRegisterHref(callbackUrl);
 
   useEffect(() => {
     if (searchParams.get('registered') === 'true') {
@@ -105,7 +111,11 @@ function LoginFormInner({ googleEnabled, githubEnabled }: LoginFormInnerProps) {
     <Card>
       <CardHeader className="text-center">
         <CardTitle>Welcome back</CardTitle>
-        <CardDescription>Sign in to your account to continue</CardDescription>
+        <CardDescription>
+          {isInvitationFlow
+            ? 'Sign in to accept your invitation'
+            : 'Sign in to your account to continue'}
+        </CardDescription>
       </CardHeader>
       <CardContent>
         {showSuccess && (
@@ -242,7 +252,7 @@ function LoginFormInner({ googleEnabled, githubEnabled }: LoginFormInnerProps) {
 
         <p className="text-center text-sm text-muted-foreground mt-6">
           Don&apos;t have an account?{' '}
-          <Link href="/register" className="text-primary hover:underline">
+          <Link href={registerHref} className="text-primary hover:underline">
             Sign up
           </Link>
         </p>

--- a/app/(auth)/login/login-form.tsx
+++ b/app/(auth)/login/login-form.tsx
@@ -9,7 +9,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { signIn } from 'next-auth/react';
-import { getSafeCallbackUrl, isInvitationCallbackUrl } from '@/lib/safe-redirect';
+import {
+  getSafeCallbackUrl,
+  isInvitationCallbackUrl,
+  isSafeRelativePath,
+} from '@/lib/safe-redirect';
 
 /**
  * Sign-up link that carries the pending destination — and, when that destination is an
@@ -88,8 +92,10 @@ function LoginFormInner({ googleEnabled, githubEnabled }: LoginFormInnerProps) {
         return;
       }
 
+      // `result.url` is whatever next-auth resolved, so it is sanitized again here — and
+      // re-checked at the sink, because `router.push` happily leaves the origin.
       const destination = getSafeCallbackUrl(result?.url || callbackUrl);
-      router.push(destination);
+      router.push(isSafeRelativePath(destination) ? destination : '/dashboard');
       router.refresh();
     } catch {
       setError('Something went wrong. Please try again.');

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,5 +1,6 @@
 import { isInviteCodeRequired } from '@/lib/feature-flags';
 import { getInvitationPreviewByToken } from '@/lib/invitations';
+import { isInvitationPreviewAllowed } from '@/lib/invitation-preview-limit';
 import RegisterPageClient from './register-page-client';
 
 interface RegisterPageProps {
@@ -11,7 +12,11 @@ export default async function RegisterPage({ searchParams }: RegisterPageProps) 
   const githubEnabled = Boolean(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET);
 
   const token = (await searchParams)?.invitationToken?.trim();
-  const preview = token ? await getInvitationPreviewByToken(token) : null;
+
+  // Unauthenticated invitation lookup — throttled per IP (and per token) before it can
+  // touch the database. When throttled we skip the lookup instead of guessing at a verdict.
+  const previewAllowed = token ? await isInvitationPreviewAllowed(token) : false;
+  const preview = token && previewAllowed ? await getInvitationPreviewByToken(token) : null;
   const invitation =
     preview && preview.status === 'PENDING' && !preview.isExpired
       ? {
@@ -29,6 +34,7 @@ export default async function RegisterPage({ searchParams }: RegisterPageProps) 
       googleEnabled={googleEnabled}
       githubEnabled={githubEnabled}
       invitation={invitation}
+      invitationLookupThrottled={Boolean(token) && !previewAllowed}
     />
   );
 }

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,15 +1,34 @@
 import { isInviteCodeRequired } from '@/lib/feature-flags';
+import { getInvitationPreviewByToken } from '@/lib/invitations';
 import RegisterPageClient from './register-page-client';
 
-export default function RegisterPage() {
+interface RegisterPageProps {
+  searchParams: Promise<{ invitationToken?: string }>;
+}
+
+export default async function RegisterPage({ searchParams }: RegisterPageProps) {
   const googleEnabled = Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET);
   const githubEnabled = Boolean(process.env.GITHUB_CLIENT_ID && process.env.GITHUB_CLIENT_SECRET);
+
+  const token = (await searchParams)?.invitationToken?.trim();
+  const preview = token ? await getInvitationPreviewByToken(token) : null;
+  const invitation =
+    preview && preview.status === 'PENDING' && !preview.isExpired
+      ? {
+          email: preview.email,
+          inviterName: preview.inviterName,
+          roleLabel: preview.roleLabel,
+          scopeLabel: preview.scopeLabel,
+          targetName: preview.targetName,
+        }
+      : null;
 
   return (
     <RegisterPageClient
       requireInviteCode={isInviteCodeRequired()}
       googleEnabled={googleEnabled}
       githubEnabled={githubEnabled}
+      invitation={invitation}
     />
   );
 }

--- a/app/(auth)/register/register-page-client.tsx
+++ b/app/(auth)/register/register-page-client.tsx
@@ -24,6 +24,8 @@ interface RegisterPageClientProps {
   googleEnabled: boolean;
   githubEnabled: boolean;
   invitation?: RegisterInvitation | null;
+  /** Preview lookup was rate-limited, so `invitation` says nothing about its validity. */
+  invitationLookupThrottled?: boolean;
 }
 
 export default function RegisterPageClient({
@@ -31,6 +33,7 @@ export default function RegisterPageClient({
   googleEnabled,
   githubEnabled,
   invitation = null,
+  invitationLookupThrottled = false,
 }: RegisterPageClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -244,6 +247,11 @@ export default function RegisterPageClient({
                   <p className="text-muted-foreground">
                     Create your account below — you&apos;ll be taken straight to it.
                   </p>
+                </div>
+              ) : isInvitationFlow && invitationLookupThrottled ? (
+                <div className="p-3 rounded-md bg-amber-500/10 text-sm">
+                  We couldn&apos;t check this invitation right now. Please wait a few minutes and
+                  open the link again.
                 </div>
               ) : isInvitationFlow ? (
                 <div className="p-3 rounded-md bg-amber-500/10 text-sm">

--- a/app/(auth)/register/register-page-client.tsx
+++ b/app/(auth)/register/register-page-client.tsx
@@ -9,24 +9,49 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { getSafeCallbackUrl } from '@/lib/safe-redirect';
+
+export interface RegisterInvitation {
+  email: string;
+  inviterName: string;
+  roleLabel: string;
+  scopeLabel: string;
+  targetName: string | null;
+}
 
 interface RegisterPageClientProps {
   requireInviteCode: boolean;
   googleEnabled: boolean;
   githubEnabled: boolean;
+  invitation?: RegisterInvitation | null;
 }
 
 export default function RegisterPageClient({
   requireInviteCode,
   googleEnabled,
   githubEnabled,
+  invitation = null,
 }: RegisterPageClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const invitationToken = useMemo(() => searchParams.get('invitationToken') || '', [searchParams]);
-  const invitedEmail = useMemo(() => searchParams.get('email') || '', [searchParams]);
+  const invitedEmail = useMemo(
+    () => invitation?.email || searchParams.get('email') || '',
+    [invitation, searchParams]
+  );
+  // Where to send the user once they are signed in — for invitations this points back
+  // at /invitations/accept so they land on the workspace/project they were invited to
+  // instead of the onboarding wizard.
+  const callbackUrl = useMemo(
+    () => getSafeCallbackUrl(searchParams.get('callbackUrl')),
+    [searchParams]
+  );
   const isInvitationFlow = invitationToken.length > 0;
   const shouldShowInviteCode = requireInviteCode && !isInvitationFlow;
+  const loginHref =
+    callbackUrl === '/dashboard'
+      ? '/login'
+      : `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`;
   const [isLoading, setIsLoading] = useState(false);
   const [oauthLoading, setOauthLoading] = useState<string | null>(null);
   const [error, setError] = useState('');
@@ -91,10 +116,11 @@ export default function RegisterPageClient({
         return;
       }
 
+      const callbackParam = `&callbackUrl=${encodeURIComponent(callbackUrl)}`;
       if (data.data?.emailVerificationRequired) {
-        router.push(`/verify-email?email=${encodeURIComponent(formData.email)}`);
+        router.push(`/verify-email?email=${encodeURIComponent(formData.email)}${callbackParam}`);
       } else {
-        router.push('/login?registered=true');
+        router.push(`/login?registered=true${callbackParam}`);
       }
     } catch {
       setError('Something went wrong. Please try again.');
@@ -106,7 +132,7 @@ export default function RegisterPageClient({
   const handleOAuthSignUp = async (provider: string) => {
     setOauthLoading(provider);
     setError('');
-    await signIn(provider, { callbackUrl: '/dashboard' });
+    await signIn(provider, { callbackUrl });
   };
 
   const hasOAuth = googleEnabled || githubEnabled;
@@ -204,9 +230,24 @@ export default function RegisterPageClient({
             )}
 
             <form onSubmit={handleRegister} className="space-y-4">
-              {isInvitationFlow ? (
-                <div className="p-3 rounded-md bg-primary/10 text-sm">
-                  You are registering via an invitation link.
+              {isInvitationFlow && invitation ? (
+                <div className="p-3 rounded-md bg-primary/10 text-sm space-y-1">
+                  <p>
+                    {invitation.inviterName} invited you to{' '}
+                    <strong>
+                      {invitation.targetName
+                        ? `${invitation.targetName} (${invitation.scopeLabel})`
+                        : `a ${invitation.scopeLabel}`}
+                    </strong>{' '}
+                    as {invitation.roleLabel}.
+                  </p>
+                  <p className="text-muted-foreground">
+                    Create your account below — you&apos;ll be taken straight to it.
+                  </p>
+                </div>
+              ) : isInvitationFlow ? (
+                <div className="p-3 rounded-md bg-amber-500/10 text-sm">
+                  This invitation link is no longer valid. Ask whoever invited you for a new one.
                 </div>
               ) : shouldShowInviteCode ? (
                 <>
@@ -261,7 +302,14 @@ export default function RegisterPageClient({
                   onChange={handleChange}
                   required
                   disabled={isLoading}
+                  readOnly={Boolean(invitation)}
+                  className={invitation ? 'bg-muted text-muted-foreground' : undefined}
                 />
+                {invitation && (
+                  <p className="text-xs text-muted-foreground">
+                    The invitation is tied to this address.
+                  </p>
+                )}
               </div>
 
               <div className="space-y-2">
@@ -307,7 +355,7 @@ export default function RegisterPageClient({
 
             <p className="text-center text-sm text-muted-foreground mt-6">
               Already have an account?{' '}
-              <Link href="/login" className="text-primary hover:underline">
+              <Link href={loginHref} className="text-primary hover:underline">
                 Sign in
               </Link>
             </p>

--- a/app/(auth)/verify-email/page.tsx
+++ b/app/(auth)/verify-email/page.tsx
@@ -8,10 +8,16 @@ import { Video, Mail, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
+import { getSafeCallbackUrl } from '@/lib/safe-redirect';
 
 function VerifyEmailContent() {
   const searchParams = useSearchParams();
   const emailParam = searchParams.get('email') || '';
+  const callbackUrl = getSafeCallbackUrl(searchParams.get('callbackUrl'));
+  const loginHref =
+    callbackUrl === '/dashboard'
+      ? '/login'
+      : `/login?callbackUrl=${encodeURIComponent(callbackUrl)}`;
   const [resendEmail, setResendEmail] = useState(emailParam);
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
@@ -107,7 +113,7 @@ function VerifyEmailContent() {
 
             <p className="text-center text-sm text-muted-foreground">
               Already verified?{' '}
-              <Link href="/login" className="text-primary hover:underline">
+              <Link href={loginHref} className="text-primary hover:underline">
                 Sign in
               </Link>
             </p>

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -135,7 +135,13 @@ export async function POST(request: NextRequest) {
     // Send verification email if SMTP is configured
     if (emailVerificationRequired) {
       const verificationToken = await createVerificationToken(normalizedEmail);
-      await sendVerificationEmail(normalizedEmail, verificationToken);
+      // Invited users are sent back to the invitation after verifying, which forwards them
+      // to the workspace/project they joined instead of the generic dashboard.
+      await sendVerificationEmail(normalizedEmail, verificationToken, {
+        next: validatedInvitationToken
+          ? `/invitations/accept?token=${encodeURIComponent(validatedInvitationToken)}`
+          : undefined,
+      });
     }
 
     const message = emailVerificationRequired

--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -3,6 +3,7 @@ import { consumeVerificationToken } from '@/lib/email-verification';
 import { rateLimit } from '@/lib/rate-limit';
 import { logError } from '@/lib/logger';
 import { getPublicOrigin } from '@/lib/request-origin';
+import { getSafeCallbackUrl } from '@/lib/safe-redirect';
 
 // A raw 32-byte hex token is exactly 64 characters.
 const TOKEN_REGEX = /^[0-9a-f]{64}$/;
@@ -31,7 +32,15 @@ export async function GET(request: NextRequest) {
       return redirectTo('/login?error=InvalidVerificationToken');
     }
 
-    return redirectTo('/login?verified=true');
+    // Keep the post-verification destination (e.g. an invitation) if one was carried along.
+    const next = getSafeCallbackUrl(request.nextUrl.searchParams.get('next'), {
+      origin,
+      fallback: '',
+    });
+
+    return redirectTo(
+      next ? `/login?verified=true&callbackUrl=${encodeURIComponent(next)}` : '/login?verified=true'
+    );
   } catch (err) {
     logError('Email verification error:', err);
     return redirectTo('/login?error=VerificationFailed');

--- a/app/invitations/accept/invitation-landing.tsx
+++ b/app/invitations/accept/invitation-landing.tsx
@@ -47,6 +47,16 @@ function UnusableInvitation({ title, message }: { title: string; message: string
   );
 }
 
+/** Too many unauthenticated invitation lookups from this client — nothing was queried. */
+export function InvitationRateLimited() {
+  return (
+    <UnusableInvitation
+      title="Too many attempts"
+      message="We couldn't check this invitation right now. Please wait a few minutes and open the link again."
+    />
+  );
+}
+
 /** Signed in, but with an account whose address the invitation was not issued to. */
 export function InvitationAccountMismatch({
   invitedEmail,

--- a/app/invitations/accept/invitation-landing.tsx
+++ b/app/invitations/accept/invitation-landing.tsx
@@ -1,0 +1,190 @@
+import Link from 'next/link';
+import { Video, UserPlus, LogIn, MailWarning } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { InvitationPreview } from '@/lib/invitations';
+
+interface InvitationLandingProps {
+  token: string;
+  preview: InvitationPreview | null;
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-background">
+      <div className="w-full max-w-md">
+        <Link href="/" className="flex items-center justify-center gap-2 mb-8">
+          <Video className="h-8 w-8 text-primary" />
+          <span className="font-bold text-2xl">OpenFrame</span>
+        </Link>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function UnusableInvitation({ title, message }: { title: string; message: string }) {
+  return (
+    <Shell>
+      <Card>
+        <CardHeader className="text-center">
+          <CardTitle className="flex items-center justify-center gap-2">
+            <MailWarning className="h-5 w-5 text-amber-500" />
+            {title}
+          </CardTitle>
+          <CardDescription>{message}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Button asChild className="w-full">
+            <Link href="/login">Sign in</Link>
+          </Button>
+          <p className="text-center text-sm text-muted-foreground">
+            Ask whoever invited you to send a new invitation link.
+          </p>
+        </CardContent>
+      </Card>
+    </Shell>
+  );
+}
+
+/** Signed in, but with an account whose address the invitation was not issued to. */
+export function InvitationAccountMismatch({
+  invitedEmail,
+  signedInEmail,
+}: {
+  invitedEmail: string;
+  signedInEmail: string;
+}) {
+  return (
+    <Shell>
+      <Card>
+        <CardHeader className="text-center">
+          <CardTitle className="flex items-center justify-center gap-2">
+            <MailWarning className="h-5 w-5 text-amber-500" />
+            Wrong account
+          </CardTitle>
+          <CardDescription>
+            This invitation was sent to <strong>{invitedEmail}</strong>, but you are signed in as{' '}
+            <strong>{signedInEmail}</strong>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Button asChild className="w-full">
+            <Link href="/signout">Sign out and switch account</Link>
+          </Button>
+          <Button asChild variant="outline" className="w-full">
+            <Link href="/dashboard">Back to dashboard</Link>
+          </Button>
+          <p className="text-center text-sm text-muted-foreground">
+            After signing out, open the invitation link from your email again.
+          </p>
+        </CardContent>
+      </Card>
+    </Shell>
+  );
+}
+
+export function InvitationLanding({ token, preview }: InvitationLandingProps) {
+  const acceptPath = `/invitations/accept?token=${encodeURIComponent(token)}`;
+  const loginHref = `/login?callbackUrl=${encodeURIComponent(acceptPath)}`;
+
+  if (!preview) {
+    return (
+      <UnusableInvitation
+        title="Invitation not found"
+        message="This invitation link is invalid. It may have been revoked or replaced by a newer one."
+      />
+    );
+  }
+
+  if (preview.status === 'CANCELED') {
+    return (
+      <UnusableInvitation
+        title="Invitation revoked"
+        message="This invitation is no longer valid."
+      />
+    );
+  }
+
+  if (preview.status === 'EXPIRED' || preview.isExpired) {
+    return (
+      <UnusableInvitation
+        title="Invitation expired"
+        message={`The invitation sent to ${preview.email} has expired.`}
+      />
+    );
+  }
+
+  const registerHref =
+    `/register?invitationToken=${encodeURIComponent(token)}` +
+    `&email=${encodeURIComponent(preview.email)}` +
+    `&callbackUrl=${encodeURIComponent(acceptPath)}`;
+
+  const alreadyAccepted = preview.status === 'ACCEPTED';
+  const targetLabel = preview.targetName
+    ? `${preview.targetName} (${preview.scopeLabel})`
+    : `a ${preview.scopeLabel}`;
+
+  return (
+    <Shell>
+      <Card>
+        <CardHeader className="text-center">
+          <CardTitle>You&apos;ve been invited</CardTitle>
+          <CardDescription>
+            {preview.inviterName} invited you to join <strong>{targetLabel}</strong> on OpenFrame as{' '}
+            {preview.roleLabel}.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-md border bg-muted/40 p-3 text-sm">
+            <p className="text-muted-foreground">
+              This invitation was sent to{' '}
+              <strong className="text-foreground">{preview.email}</strong>.{' '}
+              {preview.hasAccount || alreadyAccepted ? 'Sign in with' : 'Use'} that address to
+              accept it.
+            </p>
+          </div>
+
+          {preview.hasAccount || alreadyAccepted ? (
+            <>
+              <Button asChild className="w-full">
+                <Link href={loginHref}>
+                  <LogIn className="h-4 w-4 mr-2" />
+                  Sign in to accept
+                </Link>
+              </Button>
+              {!alreadyAccepted && (
+                <p className="text-center text-sm text-muted-foreground">
+                  Wrong address?{' '}
+                  <Link href={registerHref} className="text-primary hover:underline">
+                    Create an account instead
+                  </Link>
+                </p>
+              )}
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-muted-foreground">
+                You don&apos;t have an OpenFrame account yet. Create one to open this{' '}
+                {preview.scopeLabel} — we&apos;ll bring you right back here once you&apos;re signed
+                in.
+              </p>
+              <Button asChild className="w-full">
+                <Link href={registerHref}>
+                  <UserPlus className="h-4 w-4 mr-2" />
+                  Create your account
+                </Link>
+              </Button>
+              <p className="text-center text-sm text-muted-foreground">
+                Already have an account?{' '}
+                <Link href={loginHref} className="text-primary hover:underline">
+                  Sign in
+                </Link>
+              </p>
+            </>
+          )}
+        </CardContent>
+      </Card>
+    </Shell>
+  );
+}

--- a/app/invitations/accept/page.tsx
+++ b/app/invitations/accept/page.tsx
@@ -2,7 +2,12 @@ import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
 import { acceptInvitationTokenForUser, getInvitationPreviewByToken } from '@/lib/invitations';
-import { InvitationAccountMismatch, InvitationLanding } from './invitation-landing';
+import { isInvitationPreviewAllowed } from '@/lib/invitation-preview-limit';
+import {
+  InvitationAccountMismatch,
+  InvitationLanding,
+  InvitationRateLimited,
+} from './invitation-landing';
 
 interface InvitationAcceptPageProps {
   searchParams: Promise<{
@@ -21,7 +26,12 @@ export default async function InvitationAcceptPage({ searchParams }: InvitationA
   const session = await auth();
   if (!session?.user?.id) {
     // Signed-out visitors get the invitation itself instead of a bare login form:
-    // most of them have no account yet and need to be told to create one.
+    // most of them have no account yet and need to be told to create one. This is the
+    // only unauthenticated read of invitation data, so it is IP-throttled.
+    if (!(await isInvitationPreviewAllowed(token))) {
+      return <InvitationRateLimited />;
+    }
+
     const preview = await getInvitationPreviewByToken(token);
     return <InvitationLanding token={token} preview={preview} />;
   }

--- a/app/invitations/accept/page.tsx
+++ b/app/invitations/accept/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
 import { db } from '@/lib/db';
-import { acceptInvitationTokenForUser } from '@/lib/invitations';
+import { acceptInvitationTokenForUser, getInvitationPreviewByToken } from '@/lib/invitations';
+import { InvitationAccountMismatch, InvitationLanding } from './invitation-landing';
 
 interface InvitationAcceptPageProps {
   searchParams: Promise<{
@@ -19,14 +20,17 @@ export default async function InvitationAcceptPage({ searchParams }: InvitationA
 
   const session = await auth();
   if (!session?.user?.id) {
-    const callbackUrl = `/invitations/accept?token=${encodeURIComponent(token)}`;
-    redirect(`/login?callbackUrl=${encodeURIComponent(callbackUrl)}`);
+    // Signed-out visitors get the invitation itself instead of a bare login form:
+    // most of them have no account yet and need to be told to create one.
+    const preview = await getInvitationPreviewByToken(token);
+    return <InvitationLanding token={token} preview={preview} />;
   }
 
   const invitation = await db.invitation.findUnique({
     where: { token },
     select: {
       id: true,
+      email: true,
       status: true,
       scope: true,
       workspaceId: true,
@@ -63,7 +67,14 @@ export default async function InvitationAcceptPage({ searchParams }: InvitationA
     redirect('/dashboard?invite=expired');
   }
   if (result === 'forbidden') {
-    redirect('/dashboard?invite=wrong_account');
+    // Signed in with a different address than the one invited — say so instead of
+    // dropping the user on the dashboard with no explanation.
+    return (
+      <InvitationAccountMismatch
+        invitedEmail={invitation?.email ?? 'another address'}
+        signedInEmail={userEmail}
+      />
+    );
   }
 
   if (result === 'not_found' && invitation?.status === 'ACCEPTED') {

--- a/lib/email-verification.ts
+++ b/lib/email-verification.ts
@@ -94,7 +94,11 @@ function createTransport() {
   return nodemailer.createTransport({ host, port, secure: port === 465, auth: { user, pass } });
 }
 
-export async function sendVerificationEmail(email: string, token: string): Promise<void> {
+export async function sendVerificationEmail(
+  email: string,
+  token: string,
+  options?: { next?: string }
+): Promise<void> {
   const transporter = createTransport();
   if (!transporter) return;
 
@@ -109,7 +113,10 @@ export async function sendVerificationEmail(email: string, token: string): Promi
     return;
   }
 
-  const verifyUrl = `${baseUrl}/api/auth/verify-email?token=${encodeURIComponent(token)}`;
+  // `next` survives the round-trip so an invited user lands back on the invitation
+  // (and from there on the shared project) instead of a generic login page.
+  const nextParam = options?.next ? `&next=${encodeURIComponent(options.next)}` : '';
+  const verifyUrl = `${baseUrl}/api/auth/verify-email?token=${encodeURIComponent(token)}${nextParam}`;
   const from = process.env.SMTP_FROM || process.env.EMAIL_FROM || 'OpenFrame <info@open-frame.net>';
 
   const html = brandedEmailTemplate(

--- a/lib/invitation-preview-limit.ts
+++ b/lib/invitation-preview-limit.ts
@@ -1,0 +1,30 @@
+import { headers } from 'next/headers';
+import { checkRateLimit, getClientIpFromHeaders } from '@/lib/rate-limit';
+import { createHash } from 'crypto';
+
+/**
+ * The invitation preview surfaces (`/invitations/accept` and `/register?invitationToken=`)
+ * are reachable without a session and each render costs two database queries, so they are
+ * throttled the same way the emailed verify-email link is.
+ *
+ * Two buckets: a generous per-IP one that bounds enumeration across many tokens, and a
+ * tight per-IP+token one that stops repeated probing of a single invitation.
+ *
+ * Returns false when the caller should skip the lookup entirely.
+ */
+export async function isInvitationPreviewAllowed(token: string): Promise<boolean> {
+  const ip = getClientIpFromHeaders(await headers());
+
+  const perIp = await checkRateLimit(`invitation-preview:${ip}`, 'invitation-preview');
+  if (!perIp.allowed) return false;
+
+  // Hash the token so raw invitation secrets never reach the rate_limits table (and stay
+  // within the 256-char key bound).
+  const tokenHash = createHash('sha256').update(token).digest('hex').slice(0, 32);
+  const perToken = await checkRateLimit(
+    `invitation-preview:${ip}:${tokenHash}`,
+    'invitation-preview-token'
+  );
+
+  return perToken.allowed;
+}

--- a/lib/invitations.ts
+++ b/lib/invitations.ts
@@ -221,6 +221,64 @@ export async function createOrRefreshInvitation(params: {
   throw new Error('Failed to create invitation after retrying');
 }
 
+export interface InvitationPreview {
+  email: string;
+  role: InvitationRole;
+  roleLabel: string;
+  scope: InvitationScope;
+  scopeLabel: string;
+  status: InvitationStatus;
+  /** PENDING but past its expiry — the DB row is only flipped to EXPIRED on acceptance. */
+  isExpired: boolean;
+  inviterName: string;
+  targetName: string | null;
+  /** Whether an account already exists for the invited address. */
+  hasAccount: boolean;
+}
+
+/**
+ * Public-facing summary of an invitation, safe to render to a signed-out visitor:
+ * the token itself is the secret, and everything here was already in the email we sent
+ * to that address.
+ */
+export async function getInvitationPreviewByToken(
+  token: string
+): Promise<InvitationPreview | null> {
+  const invitation = await db.invitation.findUnique({
+    where: { token },
+    select: {
+      email: true,
+      role: true,
+      scope: true,
+      status: true,
+      expiresAt: true,
+      invitedBy: { select: { name: true } },
+      workspace: { select: { name: true } },
+      project: { select: { name: true } },
+    },
+  });
+
+  if (!invitation) return null;
+
+  const existingUser = await db.user.findUnique({
+    where: { email: invitation.email },
+    select: { id: true },
+  });
+
+  return {
+    email: invitation.email,
+    role: invitation.role,
+    roleLabel: roleLabel(invitation.role),
+    scope: invitation.scope,
+    scopeLabel: scopeLabel(invitation.scope),
+    status: invitation.status,
+    isExpired: invitation.expiresAt <= new Date(),
+    inviterName: invitation.invitedBy?.name?.trim() || 'A team member',
+    targetName: invitation.workspace?.name ?? invitation.project?.name ?? null,
+    hasAccount: Boolean(existingUser),
+  };
+}
+
 export async function getValidInvitationByToken(token: string) {
   const now = new Date();
   return db.invitation.findFirst({

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -81,6 +81,11 @@ export const RATE_LIMIT_CONFIGS: Record<string, RateLimitConfig> = {
 
   // Member management
   'invite-member': { windowMs: 60 * 60 * 1000, maxRequests: 30 }, // 30 per hour
+  // Unauthenticated invitation preview (accept landing + invited sign-up). Two buckets,
+  // as with share-unlock: a generous per-IP one that bounds token enumeration, and a
+  // tight per-IP+token one that stops repeated probing of a single invitation.
+  'invitation-preview': { windowMs: 15 * 60 * 1000, maxRequests: 120 }, // 120 per 15 min per IP
+  'invitation-preview-token': { windowMs: 15 * 60 * 1000, maxRequests: 12 }, // 12 per 15 min per IP+token
   'manage-member': { windowMs: 60 * 1000, maxRequests: 20 }, // 20 per minute
 
   // Mutations (update/delete) — moderate
@@ -188,12 +193,20 @@ function isPlausibleIp(value: string): boolean {
  * do so allows clients to spoof their IP and bypass rate limits.
  */
 export function getClientIp(request: Request): string {
+  return getClientIpFromHeaders(request.headers);
+}
+
+/**
+ * Same resolution as {@link getClientIp}, for callers that only have headers rather than a
+ * Request — server components reading `await headers()`.
+ */
+export function getClientIpFromHeaders(headers: Headers): string {
   const mode = process.env.TRUSTED_PROXY_MODE?.trim().toLowerCase();
 
   if (mode === 'cloudflare') {
     // cf-connecting-ip is injected by Cloudflare and cannot be set by clients
     // when origin access is restricted to Cloudflare's IP ranges.
-    const cfIp = request.headers.get('cf-connecting-ip');
+    const cfIp = headers.get('cf-connecting-ip');
     if (cfIp && isPlausibleIp(cfIp)) {
       return cfIp;
     }
@@ -202,11 +215,11 @@ export function getClientIp(request: Request): string {
   if (mode === 'nginx') {
     // x-real-ip is set by Nginx's real_ip_header directive (connection-level, not spoofable
     // by clients when set_real_ip_from is configured for the upstream proxy).
-    const realIp = request.headers.get('x-real-ip');
+    const realIp = headers.get('x-real-ip');
     if (realIp && isPlausibleIp(realIp)) return realIp;
 
     // x-forwarded-for last entry added by Nginx when proxy_add_x_forwarded_for is used.
-    const forwardedFor = request.headers.get('x-forwarded-for');
+    const forwardedFor = headers.get('x-forwarded-for');
     if (forwardedFor) {
       const entries = forwardedFor.split(',');
       const last = entries[entries.length - 1].trim();

--- a/lib/safe-redirect.ts
+++ b/lib/safe-redirect.ts
@@ -19,10 +19,26 @@ export function getSafeCallbackUrl(
   try {
     const parsed = new URL(value, baseOrigin);
     if (parsed.origin !== baseOrigin) return fallback;
-    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    const path = `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    // The origin check alone is not enough: an attacker can smuggle their own host into
+    // the path of an otherwise same-origin URL. `new URL('https://app.example.com//evil.com')`
+    // has our origin but a pathname of `//evil.com`, which every navigation sink below
+    // resolves as protocol-relative and follows off-site.
+    return isSafeRelativePath(path) ? path : fallback;
   } catch {
     return fallback;
   }
+}
+
+/**
+ * True when a path is safe to hand to a navigation sink (`router.push`, `<Link href>`,
+ * `NextResponse.redirect`): rooted at a single `/`, so it can only ever stay on this origin.
+ *
+ * `//evil.com` and `/\evil.com` are protocol-relative — browsers fill in the current
+ * scheme and navigate to `evil.com`.
+ */
+export function isSafeRelativePath(value: string): boolean {
+  return value.startsWith('/') && !value.startsWith('//') && !value.startsWith('/\\');
 }
 
 /** True when a sanitized path points at the invitation acceptance route. */

--- a/lib/safe-redirect.ts
+++ b/lib/safe-redirect.ts
@@ -1,0 +1,31 @@
+/**
+ * Reduce an untrusted `callbackUrl`/`next` value to a same-origin relative path.
+ * Anything absolute, cross-origin or unparsable falls back to `fallback`.
+ *
+ * Works on both sides: in the browser the origin defaults to `window.location.origin`
+ * (so next-auth's absolute `result.url` still passes), on the server pass the public origin.
+ */
+export function getSafeCallbackUrl(
+  value: string | null | undefined,
+  options?: { origin?: string; fallback?: string }
+): string {
+  const fallback = options?.fallback ?? '/dashboard';
+  if (!value) return fallback;
+
+  const baseOrigin =
+    options?.origin ??
+    (typeof window === 'undefined' ? 'http://localhost' : window.location.origin);
+
+  try {
+    const parsed = new URL(value, baseOrigin);
+    if (parsed.origin !== baseOrigin) return fallback;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return fallback;
+  }
+}
+
+/** True when a sanitized path points at the invitation acceptance route. */
+export function isInvitationCallbackUrl(path: string): boolean {
+  return path.startsWith('/invitations/accept');
+}


### PR DESCRIPTION
## Summary

Signed-out visitors who open an invitation link now see the invitation instead of a bare login form,
and the sign-up path carries the invitation all the way back to the shared workspace/project.

- `/invitations/accept` renders an invitation card for signed-out visitors: inviter, target, role and
  the address the invite was sent to. The primary CTA is "Create your account" when no account exists
  for that address and "Sign in to accept" when one does. Expired, revoked and unknown tokens get their
  own explanatory cards.
- The sign-up link carries `invitationToken`, the invited email and `callbackUrl=/invitations/accept?token=…`,
  so a freshly created account is sent back to the invitation and forwarded to the workspace/project.
  Because that path never touches `/dashboard`, the onboarding wizard no longer intercepts invited users;
  they still see it the first time they open the dashboard themselves.
- The register form shows what is being joined and locks the email field to the invited address.
- The verification email round-trips the destination through a sanitized `next` parameter, so clicking
  "Verify" in the mail also lands on the invitation. Login and verify-email keep the pending destination
  in their sign-in links.
- Signing in with a different address than the invited one now explains the mismatch and offers to switch
  accounts, instead of silently redirecting to the dashboard.
- Callback sanitization moved to `lib/safe-redirect.ts`, shared by login, register, verify-email and the
  verification route (same open-redirect guard as before, now in one place).

## Why

An invited person without an OpenFrame account was redirected straight to `/login`. Nothing said an account
was needed, the invitation context was lost, and even after signing up they were dropped into the onboarding
wizard rather than the project they were invited to.

## Scope

What areas are affected?

- [x] API routes
- [x] Auth / access control
- [ ] Database schema / migration
- [x] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [x] I used `successResponse` / `apiErrors` for API response changes.
- [x] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check -> eslint clean, prettier clean, tsc --noEmit clean

Manually tested against a throwaway local postgres (prisma db push + seeded invitations),
never against production data:

- token for an address with no account -> "You've been invited" + "Create your account" primary CTA
- token for an address that already has an account -> "Sign in to accept" primary CTA
- expired token -> "Invitation expired"
- unknown token -> "Invitation not found"
- register link: /register?invitationToken=…&email=…&callbackUrl=%2Finvitations%2Faccept%3Ftoken%3D…
- POST /api/auth/register with the token -> workspaceMember row created, invitation status ACCEPTED
- signed in, GET /invitations/accept?token=… -> 307 /workspaces/ws_test_1?invite=already_accepted
  (onboarding wizard never intercepts)
- signed in as another address -> "Wrong account: sent to X, you are signed in as Y"
```

## Breaking changes

- [x] No breaking changes
- [ ] This PR introduces a breaking change (describe below)

## Database / migration notes

No schema changes.

## Screenshots / examples (if relevant)

Known gap, left out of scope: when invite-only mode (`INVITE_CODE`) is enabled, a new invited user still
cannot sign up via OAuth — `lib/auth.ts` blocks new OAuth users with `RegistrationClosed`, and the
invitation token is only honoured on credentials registration.
