### PR TITLE
fix(scripts): make the orphan cleanups reviewable before they delete

### DIFF
--- a/scripts/bunny-orphan-cleanup.ts
+++ b/scripts/bunny-orphan-cleanup.ts
@@ -7,7 +7,10 @@ const BUNNY_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
 const ITEMS_PER_PAGE = 100;
 const MAX_PAGES = 200;
 const CHUNK_SIZE = 500;
-const DEFAULT_GRACE_HOURS = 24;
+// Seven days, not one. A video only counts as abandoned once nothing has claimed it for
+// long enough that no upload, retry or delayed finalisation could still be in flight, and
+// a day is short enough that an upload interrupted overnight looks abandoned by morning.
+const DEFAULT_GRACE_HOURS = 7 * 24;
 
 type BunnyConfig = {
   apiKey: string;
@@ -17,6 +20,7 @@ type BunnyConfig = {
 type BunnyVideo = {
   id: string;
   uploadedAt: Date;
+  title: string | null;
 };
 
 function getBunnyConfig(): BunnyConfig {
@@ -46,6 +50,17 @@ function parseVideoId(item: unknown): string | null {
       const trimmed = candidate.trim();
       if (BUNNY_VIDEO_ID_PATTERN.test(trimmed)) return trimmed;
     }
+  }
+
+  return null;
+}
+
+function parseTitle(item: unknown): string | null {
+  const record = toRecord(item);
+  if (!record) return null;
+
+  for (const candidate of [record.title, record.Title]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
   }
 
   return null;
@@ -133,7 +148,7 @@ async function listBunnyVideos(
         skippedInvalid += 1;
         continue;
       }
-      videos.push({ id, uploadedAt });
+      videos.push({ id, uploadedAt, title: parseTitle(item) });
     }
 
     if (totalItems !== null && page * ITEMS_PER_PAGE >= totalItems) break;
@@ -180,6 +195,73 @@ async function findReferencedVideoIds(videoIds: string[]): Promise<Set<string>> 
   }
 
   return referenced;
+}
+
+/**
+ * Best-effort owner for an orphan, by matching its Bunny title against titles still in the
+ * database.
+ *
+ * An orphan is by definition a video nothing in the database points at, so there is no
+ * authoritative owner to look up: `bunny-init` sends Bunny a title and nothing else, no
+ * user id and no email. What is left is the title, and it is worth matching because the
+ * common way an orphan appears is a version upload that failed and was then retried
+ * successfully, which leaves a live row carrying the same title.
+ *
+ * A hit is therefore a hint, not a fact, and the output says so. A miss means the video
+ * cannot be attributed at all from what Bunny and the database hold today.
+ */
+async function findOwnerHintsByTitle(titles: string[]): Promise<Map<string, string[]>> {
+  const hints = new Map<string, Set<string>>();
+  const unique = [...new Set(titles.filter((title): title is string => Boolean(title)))];
+
+  const remember = (title: string | null, emails: Array<string | null | undefined>) => {
+    if (!title) return;
+    const existing = hints.get(title) ?? new Set<string>();
+    for (const email of emails) {
+      if (email) existing.add(email);
+    }
+    if (existing.size > 0) hints.set(title, existing);
+  };
+
+  const ownerSelect = {
+    project: {
+      select: {
+        owner: { select: { email: true } },
+        workspace: { select: { owner: { select: { email: true } } } },
+      },
+    },
+  } as const;
+
+  for (const group of chunk(unique, CHUNK_SIZE)) {
+    const [videos, versions, assets] = await Promise.all([
+      db.video.findMany({
+        where: { title: { in: group } },
+        select: { title: true, ...ownerSelect },
+      }),
+      db.videoVersion.findMany({
+        where: { title: { in: group } },
+        select: { title: true, video: { select: ownerSelect } },
+      }),
+      db.videoAsset.findMany({
+        where: { displayName: { in: group } },
+        select: { displayName: true, video: { select: ownerSelect } },
+      }),
+    ]);
+
+    for (const row of videos) {
+      remember(row.title, [row.project.owner?.email, row.project.workspace.owner?.email]);
+    }
+    for (const row of versions) {
+      const project = row.video.project;
+      remember(row.title, [project.owner?.email, project.workspace.owner?.email]);
+    }
+    for (const row of assets) {
+      const project = row.video.project;
+      remember(row.displayName, [project.owner?.email, project.workspace.owner?.email]);
+    }
+  }
+
+  return new Map([...hints].map(([title, emails]) => [title, [...emails].sort()]));
 }
 
 async function deleteBunnyVideo(
@@ -238,6 +320,32 @@ async function main() {
   const referenced = await findReferencedVideoIds(eligibleIds);
 
   const orphanIds = eligibleIds.filter((id) => !referenced.has(id));
+
+  // A dry run that only reports a count cannot be acted on: the point of it is to see
+  // what would go before anything does. Deleting prints the same list, so a real run is
+  // auditable after the fact too.
+  if (orphanIds.length > 0) {
+    const byId = new Map(eligible.map((video) => [video.id, video]));
+    const orphanTitles = orphanIds
+      .map((orphanId) => byId.get(orphanId)?.title)
+      .filter((title): title is string => Boolean(title));
+    const ownerHints = await findOwnerHintsByTitle(orphanTitles);
+
+    console.log(
+      `[bunny-orphan-cleanup] Orphans ${dryRun ? 'that would be deleted' : 'to delete'}:`
+    );
+    for (const orphanId of orphanIds) {
+      const video = byId.get(orphanId);
+      const uploadedAt = video?.uploadedAt.toISOString() ?? 'unknown date';
+      const title = video?.title ?? 'untitled';
+      const emails = video?.title ? (ownerHints.get(video.title) ?? []) : [];
+      // "possibly" is load-bearing: this is a title match, not a stored owner.
+      const owner =
+        emails.length > 0 ? `possibly ${emails.join(', ')}` : 'owner unknown (no title match)';
+      console.log(`[bunny-orphan-cleanup]   ${orphanId}  ${uploadedAt}  ${title}  ${owner}`);
+    }
+  }
+
   let deleted = 0;
   let alreadyMissing = 0;
   let failed = 0;

--- a/scripts/r2-orphan-cleanup.ts
+++ b/scripts/r2-orphan-cleanup.ts
@@ -8,7 +8,12 @@ import { r2Client, R2_BUCKET_NAME } from '../lib/r2';
 import { cleanupExpiredBillingWorkspaces } from './expired-billing-cleanup';
 import { logError } from '@/lib/logger';
 
-const UNATTACHED_UPLOAD_TTL_MS = 15 * 60 * 1000;
+// Seven days. This was fifteen minutes, which is shorter than a slow multipart upload of
+// a large file: an object still being written, or written but not yet finalised into a
+// row, looked abandoned and could be deleted out from under the upload that was creating
+// it. An object only counts as abandoned once nothing has claimed it for long enough that
+// no upload, retry or delayed finalisation could still be in flight.
+const UNATTACHED_UPLOAD_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 const CHUNK_SIZE = 500;
 const PREFIXES = ['images/', 'voice/', 'videos/'] as const;
 
@@ -38,6 +43,50 @@ function keyToProxyUrl(key: string): string | null {
     return filename ? `/api/upload/video/${filename}` : null;
   }
   return null;
+}
+
+/**
+ * The owner of each orphaned object key, from the upload session that created it.
+ *
+ * Unlike the Bunny side, this is an answer rather than a guess: `videoUploadSession` keeps
+ * `objectKey` alongside the user who initiated the upload, and the row survives even when
+ * the upload never became a video, which is exactly the case that produces an orphan.
+ * Both the initiating user and the billed user are reported when they differ, because the
+ * billed one is who paid for the bytes.
+ */
+async function findUploadSessionOwners(keys: string[]): Promise<Map<string, string>> {
+  const owners = new Map<string, string>();
+
+  for (const group of chunk(keys, CHUNK_SIZE)) {
+    // VideoUploadSession holds the ids but declares no relation to User, so the addresses
+    // are resolved in a second query rather than by widening the schema for a script.
+    const sessions = await db.videoUploadSession.findMany({
+      where: { objectKey: { in: group } },
+      select: { objectKey: true, status: true, userId: true, billedUserId: true },
+    });
+    if (sessions.length === 0) continue;
+
+    const userIds = [
+      ...new Set(sessions.flatMap((session) => [session.userId, session.billedUserId])),
+    ];
+    const users = await db.user.findMany({
+      where: { id: { in: userIds } },
+      select: { id: true, email: true },
+    });
+    const emailById = new Map(users.map((user) => [user.id, user.email]));
+
+    for (const session of sessions) {
+      const initiator = emailById.get(session.userId) ?? null;
+      const billed = emailById.get(session.billedUserId) ?? null;
+      const who =
+        billed && billed !== initiator
+          ? `${initiator ?? 'unknown'} (billed: ${billed})`
+          : (initiator ?? billed ?? 'unknown');
+      owners.set(session.objectKey, `${who} [session ${session.status.toLowerCase()}]`);
+    }
+  }
+
+  return owners;
 }
 
 function chunk<T>(items: T[], size: number): T[][] {
@@ -181,16 +230,27 @@ async function main() {
 
   let deleted = 0;
   let failed = 0;
-  let orphaned = 0;
-  let referencedCount = 0;
 
-  for (const candidate of candidates) {
-    if (referenced.has(candidate.url)) {
-      referencedCount += 1;
-      continue;
+  // A dry run that only reports a count cannot be acted on: the point of it is to see
+  // what would go before anything does. Deleting prints the same list, so a real run is
+  // auditable after the fact too.
+  const orphanCandidates = candidates.filter((candidate) => !referenced.has(candidate.url));
+  const referencedCount = candidates.length - orphanCandidates.length;
+  const orphaned = orphanCandidates.length;
+
+  if (orphanCandidates.length > 0) {
+    const owners = await findUploadSessionOwners(orphanCandidates.map((c) => c.key));
+
+    console.log(`[r2-orphan-cleanup] Orphans ${dryRun ? 'that would be deleted' : 'to delete'}:`);
+    for (const candidate of orphanCandidates) {
+      const email = owners.get(candidate.key);
+      console.log(
+        `[r2-orphan-cleanup]   ${candidate.key}  ${email ?? 'owner unknown (no upload session)'}`
+      );
     }
+  }
 
-    orphaned += 1;
+  for (const candidate of orphanCandidates) {
     if (dryRun) continue;
 
     try {


### PR DESCRIPTION
## Summary

Makes `bunny:cleanup-orphans` and `r2:cleanup-orphans` safe to run unattended, which is what a scheduled task needs them to be.

**They now list what they would delete.** A dry run used to report a count and nothing else. "Orphaned: 31" is not something anyone can approve: it says how many objects would go, never which ones. Both scripts print every orphan they would delete, and print the same list when deleting, so a real run is auditable afterwards too.

**Each line names the owner, as far as each provider can answer.** These differ, and the output is explicit about which kind of answer it is giving:

- R2 reads it out of `videoUploadSession`, which keeps `objectKey` alongside the initiating and the billed user, and whose row survives an upload that never became a video. That is exactly the case that produces an orphan, so this is an answer rather than a guess. Both addresses are printed when they differ, since the billed one is who paid for the bytes, along with the session status.
- Bunny has no equivalent. `bunny-init` sends the provider a title and nothing else, no user id and no email, and an orphan by definition has no row pointing at it, so there is nothing authoritative to look up. The title is matched against titles still in the database instead, which catches the common shape: a version upload that failed and was retried successfully leaves a live row carrying the same title. A hit prints as `possibly <email>`, a miss as `owner unknown (no title match)`.

**Both grace periods go to seven days.** Bunny counted a video abandoned after 24 hours. R2 counted an object abandoned after **15 minutes**, which is shorter than a slow multipart upload of a large file: an object still being written, or written but not yet finalised into a row, looked abandoned and could be deleted out from under the upload creating it.

## Why

Neither script was scheduled anywhere: no cron, no entrypoint hook, nothing in CI. Wiring the Bunny one up to a Coolify scheduled task against production is what surfaced all of this. Its first dry run reported 31 orphans out of 171 videos and gave no way to tell whether those 31 were genuinely abandoned uploads or something still in use, which is not a decision anyone should make blind.

The R2 window is the more serious of the two. Fifteen minutes is inside the time a large upload can legitimately take, so the cleanup could race an upload in progress rather than only collecting dead objects.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [ ] UI / UX
- [ ] Documentation
- [x] Other

Other: two maintenance scripts. No runtime code path changes.

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

The schema is untouched: `videoUploadSession` declares no relation to `User`, so the addresses are resolved in a second query rather than widening the schema for a script. Nothing here is an API route or an access check.

Validation notes:

```text
tsc --noEmit                  clean
eslint --max-warnings=0       clean
prettier                      clean
```

## Breaking changes

- [x] No breaking changes
- [ ] This PR introduces a breaking change (describe below)

Both scripts keep their `--dry-run` flag and their exit behaviour. The only behavioural change is that fewer objects qualify as orphans, because the grace period is longer, and that the logs are more detailed.

## Database / migration notes

No schema change.

## Screenshots / examples (if relevant)

```text
[r2-orphan-cleanup] Orphans that would be deleted:
[r2-orphan-cleanup]   videos/1e4c….mp4  ada@example.com [session initiated]
[r2-orphan-cleanup]   images/9b21….png  owner unknown (no upload session)

[bunny-orphan-cleanup] Orphans that would be deleted:
[bunny-orphan-cleanup]   8f3c…  2026-07-01T09:12:44.000Z  Ad campaign cut 3  possibly ada@example.com
[bunny-orphan-cleanup]   1a77…  2026-06-28T17:02:10.000Z  untitled  owner unknown (no title match)
```
