### PR TITLE
fix(scripts): count a Bunny id referenced by url, not only by column

### DIFF
--- a/scripts/bunny-orphan-cleanup.ts
+++ b/scripts/bunny-orphan-cleanup.ts
@@ -166,32 +166,53 @@ function chunk<T>(items: T[], size: number): T[][] {
   return out;
 }
 
+/**
+ * Every Bunny id the database still points at.
+ *
+ * A Bunny id is stored in two places per row, and both are checked. `VideoVersion.videoId`
+ * and `VideoAsset.providerVideoId` hold the guid on its own, while `originalUrl` and
+ * `sourceUrl` embed the same guid inside
+ * `https://iframe.mediadelivery.net/embed/<library>/<guid>`. They are written together, so
+ * they normally agree, but this decides what gets deleted: a row whose id column was left
+ * empty or drifted while its url still carried the guid would make a live video look
+ * orphaned. Reading both makes disagreement harmless rather than destructive.
+ */
 async function findReferencedVideoIds(videoIds: string[]): Promise<Set<string>> {
   const referenced = new Set<string>();
 
   for (const group of chunk(videoIds, CHUNK_SIZE)) {
     const [versionRows, assetRows] = await Promise.all([
       db.videoVersion.findMany({
-        where: {
-          providerId: 'bunny',
-          videoId: { in: group },
-        },
-        select: { videoId: true },
+        where: { providerId: 'bunny' },
+        select: { videoId: true, originalUrl: true },
       }),
       db.videoAsset.findMany({
-        where: {
-          provider: 'BUNNY',
-          providerVideoId: { in: group },
-        },
-        select: { providerVideoId: true },
+        where: { provider: 'BUNNY' },
+        select: { providerVideoId: true, sourceUrl: true },
       }),
     ]);
-    versionRows.forEach((row) => {
-      if (row.videoId) referenced.add(row.videoId);
-    });
-    assetRows.forEach((row) => {
-      if (row.providerVideoId) referenced.add(row.providerVideoId);
-    });
+
+    // Every Bunny row is read rather than filtered by id, because the url has to be
+    // searched for a guid it merely contains. There are as many of these rows as there
+    // are Bunny videos in the product, so this is one small scan instead of one LIKE per
+    // candidate id.
+    const ids = new Set(group);
+    const urls: string[] = [];
+
+    for (const row of versionRows) {
+      if (row.videoId && ids.has(row.videoId)) referenced.add(row.videoId);
+      if (row.originalUrl) urls.push(row.originalUrl);
+    }
+    for (const row of assetRows) {
+      if (row.providerVideoId && ids.has(row.providerVideoId)) referenced.add(row.providerVideoId);
+      if (row.sourceUrl) urls.push(row.sourceUrl);
+    }
+
+    for (const url of urls) {
+      for (const id of group) {
+        if (!referenced.has(id) && url.includes(id)) referenced.add(id);
+      }
+    }
   }
 
   return referenced;


### PR DESCRIPTION
## Summary

Follow-up to #46. The Bunny orphan lookup only read the id columns, so a row could hold a live Bunny video while the script counted it as an orphan and deleted it.

A Bunny guid is stored twice per row:

- on its own, in `VideoVersion.videoId` and `VideoAsset.providerVideoId`
- inside `originalUrl` and `sourceUrl`, as `https://iframe.mediadelivery.net/embed/<library>/<guid>`

`findReferencedVideoIds()` read only the first. Both are read now, so a row that is missing or has drifted in one place still protects its video through the other.

The Bunny rows are also read in a single pass rather than filtered per candidate id. The url check is a substring test, and there are only as many of these rows as there are Bunny videos in the product, so one small scan replaces one `LIKE` per candidate.

## Why

Both columns are written together, so they normally agree, and nothing observed says they currently disagree. The reason to fix it anyway is what the query is for: it is the sole input to a delete against production media. A single row with an empty or drifted id column would present a live video as an orphan, and the script would delete something the product is still serving. Reading both makes a disagreement harmless rather than destructive.

This landed on the branch of #46 after that PR had already merged, so it never reached master. Same commit, opened properly this time.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [ ] UI / UX
- [ ] Documentation
- [x] Other

Other: one maintenance script. No runtime code path changes.

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
tsc --noEmit                  clean
eslint --max-warnings=0       clean
prettier --check              clean
```

Worth re-running `bun run bunny:cleanup-orphans:dry` after this deploys. If the orphan count drops, the difference was live videos that the id-column-only lookup had been mislabelling.

## Breaking changes

- [x] No breaking changes
- [ ] This PR introduces a breaking change (describe below)

Strictly fewer videos qualify as orphans than before.

## Database / migration notes

No schema change.
