### PR TITLE
docs(terms): match the export window to the cleanup the product runs

### DIFF
--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -274,8 +274,9 @@ export default function TermsOfServicePage() {
             </p>
             <p className="mt-3">
               Except where the law requires otherwise or the content itself is unlawful, your User
-              Content will remain available for export for thirty (30) days after termination, after
-              which it may be permanently deleted.
+              Content will remain available for export for fifteen (15) days after termination,
+              after which it may be permanently deleted. Write to us within that window if you need
+              a copy and can no longer reach it yourself.
             </p>
             <p className="mt-3">
               You may cancel your account at any time through your billing settings or by contacting


### PR DESCRIPTION
## Summary

Termination promised thirty days of export; the storage cleanup deletes fifteen days after billing access ends. The terms now say fifteen, which is the window the product actually enforces (`STORAGE_CLEANUP_GRACE_DAYS` in `lib/billing.ts`).

The same sentence also implied the export stays self-service during that window. It does not: access ends with billing, so a user inside the window cannot reach their own footage. The sentence now points them at us for a copy instead.

## Why

The scheduled cleanup had never actually deleted anything (see #48), so the gap between the two numbers never mattered. With that fixed the product would delete content the terms still covered, which is the wrong way round for a promise to be broken.

Fifteen is the enforced number, so the terms are what moved. Note for the record: the owners currently queued for deletion cancelled while the thirty day text was live, so narrowing the text today does not necessarily apply to them.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [ ] UI / UX
- [x] Documentation
- [ ] Other

One paragraph of the terms page. No code, no behavior change.

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [x] I used `successResponse` / `apiErrors` for API response changes.
- [x] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [x] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check    clean (ran by the pre-commit hook on this file)

Cross-checked the numbers:
  lib/billing.ts        STORAGE_CLEANUP_GRACE_DAYS = 15
  app/terms/page.tsx    fifteen (15) days after termination
  app/privacy/page.tsx  no competing retention window
  app/refund/page.tsx   14 day refund window, unrelated
```

## Breaking changes

- [x] No breaking changes

## Database / migration notes

None.
