### PR TITLE
fix(tests): stop the scoreboard suite from depending on the weekday

### DIFF
--- a/tests/api/analytics-scoreboard.test.ts
+++ b/tests/api/analytics-scoreboard.test.ts
@@ -17,6 +17,28 @@ function daysAgo(days: number): Date {
   return date;
 }
 
+/**
+ * The Monday this week started, in UTC.
+ *
+ * Anything asserted per week has to be seeded from here rather than from
+ * `daysAgo`: weeks start on Monday, so "three days ago" is last week on a
+ * Wednesday and this week on a Saturday, and a suite written the second way
+ * fails on the days the calendar disagrees.
+ */
+function startOfThisWeek(): Date {
+  const now = new Date();
+  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  start.setUTCDate(start.getUTCDate() - ((start.getUTCDay() + 6) % 7));
+  return start;
+}
+
+/** `days` into the week beginning at `weekStart`. Negative walks back a week. */
+function intoWeek(weekStart: Date, days: number): Date {
+  const date = new Date(weekStart);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date;
+}
+
 let sequence = 0;
 
 async function seedEvent(params: {
@@ -61,17 +83,19 @@ describe('getScoreboard', () => {
   it('counts a returning visitor once per week, not once per visit', async () => {
     // Landing views are deduped per visitor per day, so the same person on three
     // days is three rows. Weekly visitors is a distinct count over the id.
-    for (const days of [1, 2, 3]) {
+    // Seeded into last week, which is whole however the suite is scheduled.
+    const lastWeek = intoWeek(startOfThisWeek(), -7);
+    for (const day of [0, 1, 2]) {
       await seedEvent({
         name: 'LANDING_VIEW',
-        occurredAt: daysAgo(days),
+        occurredAt: intoWeek(lastWeek, day),
         anonymousId: 'visitor-one',
         channel: 'GITHUB',
       });
     }
     await seedEvent({
       name: 'LANDING_VIEW',
-      occurredAt: daysAgo(1),
+      occurredAt: intoWeek(lastWeek, 1),
       anonymousId: 'visitor-two',
       channel: 'GOOGLE',
     });
@@ -112,9 +136,11 @@ describe('getScoreboard', () => {
   });
 
   it('carries subscriptions started before the window into the running total', async () => {
+    // The pair has to land in the week the assertions read, which is this one.
+    const thisWeek = startOfThisWeek();
     await seedEvent({ name: 'SUBSCRIPTION_STARTED', occurredAt: daysAgo(120) });
-    await seedEvent({ name: 'SUBSCRIPTION_STARTED', occurredAt: daysAgo(3) });
-    await seedEvent({ name: 'SUBSCRIPTION_CANCELED', occurredAt: daysAgo(3) });
+    await seedEvent({ name: 'SUBSCRIPTION_STARTED', occurredAt: thisWeek });
+    await seedEvent({ name: 'SUBSCRIPTION_CANCELED', occurredAt: thisWeek });
 
     const scoreboard = await getScoreboard({ weeks: 2 });
     const last = scoreboard.weeks[scoreboard.weeks.length - 1];


### PR DESCRIPTION
## Summary

The scoreboard tests seeded their events with `daysAgo(1..3)` and then asserted on weekly buckets. Weeks are grouped with `date_trunc('week', ...)`, which starts on Monday, so those offsets cross a week boundary on some days of the week and not others. The seeds now hang off a week boundary: the visitor events go into last week, which is whole whenever the suite runs, and the subscription pair goes into this week, which is the week those assertions read.

No production code changed.

## Why

`master` went red on the run for b8d68a9, on a Wednesday:

- `tests/api/analytics-scoreboard.test.ts:82` — `daysAgo(3)` was a Sunday, so `visitor-one` was counted once in each of two weeks. Expected 2, got 3.
- `tests/api/analytics-scoreboard.test.ts:124` — `SUBSCRIPTION_STARTED` landed in the previous week, so the last week's `newPaid` was empty. Expected 1, got 0.

The suite passed on Monday and Thursday through Sunday, and failed on Tuesday and Wednesday. Nothing was wrong with the queries.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [ ] UI / UX
- [ ] Documentation
- [x] Other — test suite only

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed. (schema untouched)
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes. (no API changes)
- [ ] I used `auth()` and shared access checks where relevant. (no access-control changes)
- [ ] I updated docs when behavior changed. (no behavior change)
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
$ bunx vitest run --project api
 Test Files  32 passed (32)
      Tests  1060 passed (1060)

$ bun run check   (in podman)
 eslint --max-warnings=0        clean
 prettier --check .             All matched files use Prettier code style!
 tsc --noEmit                   clean
```

Run on a Wednesday, the weekday the CI failure reproduced on. The week helpers were also replayed against 14 consecutive days at four times of day: all 56 simulated clocks put the seeds in the intended week, with every timestamp inside the query window and in the past.

## Breaking changes

- [x] No breaking changes

## Database / migration notes

None.