### PR TITLE
fix(upload): give a full trial account the upgrade link where it reads the refusal

### DIFF
--- a/components/video-drag-drop-uploader.tsx
+++ b/components/video-drag-drop-uploader.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { CheckCircle2, Loader2, UploadCloud, XCircle } from 'lucide-react';
 import { toast } from 'sonner';
@@ -22,6 +23,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { resolvePublicBunnyCdnHostname } from '@/lib/bunny-cdn';
+import { isTrialStorageError, toastApiError } from '@/lib/client/api-error';
 import {
   cleanupPendingProjectUpload,
   getDefaultTitleFromFile,
@@ -46,6 +48,8 @@ type QueueItem = {
   status: QueueItemStatus;
   progress: number;
   error?: string;
+  /** The failure was the trial ceiling, so the row shows the way out. */
+  errorIsTrialLimit?: boolean;
 };
 
 interface VideoDragDropUploaderProps {
@@ -306,12 +310,17 @@ export function VideoDragDropUploader({
           failCount += 1;
 
           const message = error instanceof Error ? error.message : 'Failed to upload video';
+          const isTrialLimit = isTrialStorageError(error);
           setQueue((prev) =>
             prev.map((entry) =>
-              entry.id === item.id ? { ...entry, status: 'error', error: message } : entry
+              entry.id === item.id
+                ? { ...entry, status: 'error', error: message, errorIsTrialLimit: isTrialLimit }
+                : entry
             )
           );
-          toast.error(`${item.file.name}: ${message}`);
+          // Keeps the error code alive to the toast: a trial account that has run
+          // out of room is shown the plan rather than just told the upload failed.
+          toastApiError(error, 'Failed to upload video', { prefix: item.file.name });
         }
       }
 
@@ -500,7 +509,17 @@ export function VideoDragDropUploader({
                     <div className="min-w-0 flex-1">
                       <p className="truncate font-medium">{item.file.name}</p>
                       {item.error ? (
-                        <p className="truncate text-xs text-destructive">{item.error}</p>
+                        <p className="text-xs text-destructive">
+                          <span className="align-middle">{item.error}</span>
+                          {item.errorIsTrialLimit && (
+                            <Link
+                              href="/settings"
+                              className="ml-1 align-middle font-medium underline underline-offset-2"
+                            >
+                              Upgrade
+                            </Link>
+                          )}
+                        </p>
                       ) : (
                         <p className="truncate text-xs text-muted-foreground">
                           {getDefaultTitleFromFile(item.file)}

--- a/lib/client/api-error.ts
+++ b/lib/client/api-error.ts
@@ -42,6 +42,14 @@ export function apiRequestError(
   return new ApiRequestError(payload?.error || fallback, payload?.code);
 }
 
+/**
+ * Whether this failure is the trial ceiling, for callers that draw the way out
+ * themselves rather than handing it to `toastApiError`.
+ */
+export function isTrialStorageError(source: unknown): boolean {
+  return codeOf(source) === API_ERROR_CODES.TRIAL_STORAGE_LIMIT_EXCEEDED;
+}
+
 function codeOf(source: unknown): string | null {
   if (source instanceof ApiRequestError) return source.code;
   if (source && typeof source === 'object' && 'code' in source) {
@@ -82,13 +90,15 @@ export function toastApiError(
   const message = messageOf(source, fallback);
   const text = options.prefix ? `${options.prefix}: ${message}` : message;
 
-  if (codeOf(source) === API_ERROR_CODES.TRIAL_STORAGE_LIMIT_EXCEEDED) {
+  if (isTrialStorageError(source)) {
     toast.error(text, {
       // Longer than a plain error: this one is asking for a decision rather than
       // just reporting, and it disappears under the cursor at the usual timing.
       duration: 12000,
       action: {
-        label: 'See plans',
+        // The message ends in "Upgrade to get 200 GB", so the button is the verb
+        // that sentence just used rather than a second name for the same thing.
+        label: 'Upgrade',
         onClick: () => {
           window.location.href = '/settings';
         },


### PR DESCRIPTION
## Summary

A trial account that fills its 3 GB gets `Your free trial includes 3 GB of storage. Upgrade to get 200 GB.` and, in the video uploader, nothing to click. `toastApiError` already attaches an action for that error code, but the uploader never called it: it caught the error, pulled `.message` off it, and passed the bare string to `toast.error`, dropping the code that the action depends on.

- The uploader's per-file failure now goes through `toastApiError`, so the trial ceiling toast carries the action and the longer duration.
- The queue row repeats the link inline, so it is still there once the toast times out. It renders only for the trial ceiling, not for an ordinary upload failure.
- The action reads `Upgrade` instead of `See plans`, matching the verb the message itself uses. Both destinations are `/settings`, where the Billing card is the first thing on the page.
- `isTrialStorageError` is exported from `lib/client/api-error.ts` for the inline case; `toastApiError` now uses it too instead of its own inline comparison.

## Why

The account most likely to hit the storage ceiling is a trial account uploading its first videos, and the uploader was the one caller that showed the refusal with no way out. Reading "Upgrade to get 200 GB" with nothing to press is a dead end.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [x] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [ ] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check (lint + format:check + typecheck) passes.
No manual run against a real full-trial account: the change is client-side rendering of an
existing 507 response, and the error path was verified by reading it rather than by triggering it.
```

## Breaking changes

- [x] No breaking changes

## Database / migration notes

None.
