### PR TITLE
fix(upload): give the Add Video page the upgrade link too

### DIFF
--- a/app/(dashboard)/projects/[projectId]/videos/new/new-video-page-client.tsx
+++ b/app/(dashboard)/projects/[projectId]/videos/new/new-video-page-client.tsx
@@ -27,6 +27,7 @@ import {
   type VideoSource,
 } from '@/lib/video-providers';
 import { resolvePublicBunnyCdnHostname } from '@/lib/bunny-cdn';
+import { isTrialStorageError } from '@/lib/client/api-error';
 import {
   cleanupPendingProjectUpload,
   getDefaultTitleFromFile,
@@ -68,7 +69,20 @@ export default function NewVideoPageClient({
   const fileDragDepthRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const [submitError, setSubmitError] = useState('');
+  const [submitError, setSubmitErrorText] = useState('');
+  const [submitErrorIsTrialLimit, setSubmitErrorIsTrialLimit] = useState(false);
+
+  /**
+   * The message and whether it is the trial ceiling, set together.
+   *
+   * The second half is what draws the upgrade link, so it must not outlive the
+   * error it belongs to. Every caller goes through here and hands over the
+   * failure it caught rather than keeping a flag of its own.
+   */
+  const setSubmitError = useCallback((message: string, source?: unknown) => {
+    setSubmitErrorText(message);
+    setSubmitErrorIsTrialLimit(Boolean(message) && isTrialStorageError(source));
+  }, []);
   const [formData, setFormData] = useState({
     title: '',
     description: '',
@@ -226,7 +240,7 @@ export default function NewVideoPageClient({
         }));
       }
     },
-    [formData.title]
+    [formData.title, setSubmitError]
   );
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -362,7 +376,7 @@ export default function NewVideoPageClient({
         activeTusUploadRef.current = null;
         failCount += 1;
         const message = error instanceof Error ? error.message : 'Upload failed';
-        setSubmitError(`${file.name}: ${message}`);
+        setSubmitError(`${file.name}: ${message}`, error);
         setUploadStatus('');
       }
     }
@@ -420,7 +434,7 @@ export default function NewVideoPageClient({
 
         if (!response.ok) {
           const data = await response.json();
-          setSubmitError(data.error || 'Failed to add video');
+          setSubmitError(data.error || 'Failed to add video', data);
           return;
         }
 
@@ -447,7 +461,10 @@ export default function NewVideoPageClient({
       await uploadMultipleFiles(selectedFiles);
     } catch (error: unknown) {
       console.error('Failed to add video:', error);
-      setSubmitError(error instanceof Error ? error.message : 'An unexpected error occurred');
+      setSubmitError(
+        error instanceof Error ? error.message : 'An unexpected error occurred',
+        error
+      );
       // Cleared on the failure path too. Leaving it set showed the error above a stale
       // "Initializing upload...", so the form claimed to be doing both at once.
       setUploadStatus('');
@@ -705,9 +722,19 @@ export default function NewVideoPageClient({
             ) : null}
 
             {submitError && (
-              <p className="text-sm text-destructive flex items-center gap-1">
-                <AlertCircle className="h-4 w-4" />
-                {submitError}
+              <p className="text-sm text-destructive flex items-start gap-1">
+                <AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+                <span>
+                  {submitError}
+                  {submitErrorIsTrialLimit && (
+                    <Link
+                      href="/settings"
+                      className="ml-1 font-medium underline underline-offset-2"
+                    >
+                      Upgrade
+                    </Link>
+                  )}
+                </span>
               </p>
             )}
 


### PR DESCRIPTION
## Summary

The Add Video page (`projects/[projectId]/videos/new`) now shows an `Upgrade` link next to the storage refusal, the same way the drag-and-drop uploader does. `submitError` carries a second piece of state saying whether the failure was the trial ceiling, set in the same call as the message so the link cannot outlive the error it belongs to, and the three places that set it pass the failure they caught.

## Why

#56 fixed the toast path in `components/video-drag-drop-uploader.tsx`, but the Add Video form draws its own error line and threw the API error code away, so a full trial account read "Your free trial includes 3 GB of storage. Upgrade to get 200 GB." with nothing to click. That page is where a single-file upload from the project screen lands, so it is the one people actually hit the ceiling on.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [x] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [ ] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check (podman, oven/bun:alpine): lint, format:check and typecheck all pass.
Not manually re-run against a real trial account that is over quota; the link is
driven by the TRIAL_STORAGE_LIMIT_EXCEEDED code the API already returns, the same
code the uploader toast keys off.
```

## Breaking changes

- [x] No breaking changes