### PR TITLE
fix(theme): stop the theme menu from crowding its own top edge

### DIFF
--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Moon, Sun } from 'lucide-react';
+import { Monitor, Moon, Sun } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
 import {
@@ -17,23 +17,27 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon">
+        <Button variant="ghost" size="icon" className="relative">
           <Sun className="h-4 w-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-4 w-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
+      <DropdownMenuContent
+        align="end"
+        sideOffset={10}
+        className="w-40 min-w-40 rounded-md border p-1"
+      >
         <DropdownMenuItem onClick={() => setTheme('light')}>
-          <Sun className="h-4 w-4 mr-2" />
+          <Sun />
           Light
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme('dark')}>
-          <Moon className="h-4 w-4 mr-2" />
+          <Moon />
           Dark
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme('system')}>
-          <span className="h-4 w-4 mr-2">💻</span>
+          <Monitor />
           System
         </DropdownMenuItem>
       </DropdownMenuContent>


### PR DESCRIPTION
## Summary

Theme dropdown now uses the same shell as the account menu next to it: `p-1` inner padding, `sideOffset={10}`, a fixed `w-40`, and a rounded border. The System row swaps its 💻 emoji for the lucide `Monitor` icon, and the per-item `h-4 w-4 mr-2` classes are gone since `DropdownMenuItem` already sizes icons and sets the gap. The trigger button gets `relative` so its absolutely positioned moon icon has a positioning context of its own.

## Why

The menu had no inner padding, so the first row's icon sat flush against the popover's top border and the box looked clipped under the header. The emoji also rendered in colour at a different baseline than the two lucide icons, breaking the icon column.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [x] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check: lint, prettier and tsc all clean.
Opened the menu on /dashboard in dark mode: three rows share one icon column,
nothing touches the popover border, box clears the header bar.
```

## Breaking changes

- [x] No breaking changes
- [ ] This PR introduces a breaking change (describe below)

## Database / migration notes

None.
