### PR TITLE
feat(player): raise the playback speed ceiling off YouTube's limit

### DIFF
--- a/components/video-page-content.tsx
+++ b/components/video-page-content.tsx
@@ -39,6 +39,7 @@ import type {
 import { useApprovals } from '@/components/video-page/hooks/use-approvals';
 import { useVideoAssets } from '@/components/video-page/hooks/use-video-assets';
 import { resolvePublicBunnyCdnHostname } from '@/lib/bunny-cdn';
+import { getSpeedOptionsForProvider } from '@/components/video-page/hooks/video-player-utils';
 
 function formatTime(seconds: number): string {
   const totalSeconds = Math.floor(seconds);
@@ -63,8 +64,6 @@ function formatBunnyQualityLabel(
   }
   return `Level ${index + 1}`;
 }
-
-const SPEED_OPTIONS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 
 export type VideoPageMode = 'dashboard' | 'watch';
 
@@ -275,6 +274,7 @@ export function VideoPageContent({
     );
   }, [video?.versions, activeVersionId]);
   const activeProviderId = activeVersion?.providerId;
+  const speedOptions = getSpeedOptionsForProvider(activeProviderId);
   const activeVersionDuration = activeVersion?.duration;
   const bunnyCdnHostname = useMemo(() => resolvePublicBunnyCdnHostname(), []);
   const embedUrl = useMemo(() => {
@@ -354,7 +354,7 @@ export function VideoPageContent({
     playerRef,
     formatTime,
     formatBunnyQualityLabel,
-    speedOptions: SPEED_OPTIONS,
+    speedOptions,
     scheduleWatchProgressSaveRef,
     setViewingAnnotation,
   });
@@ -819,7 +819,7 @@ export function VideoPageContent({
             qualityOptions={qualityOptions}
             handleQualityChange={handleQualityChange}
             playbackSpeed={playbackSpeed}
-            speedOptions={SPEED_OPTIONS}
+            speedOptions={speedOptions}
             handleSpeedChange={handleSpeedChange}
             toggleFullscreen={toggleFullscreen}
             showComments={showComments}

--- a/components/video-page/bunny-preview-player.tsx
+++ b/components/video-page/bunny-preview-player.tsx
@@ -21,6 +21,10 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { resolvePublicBunnyCdnHostname } from '@/lib/bunny-cdn';
 import { cn } from '@/lib/utils';
+import {
+  NATIVE_SPEED_OPTIONS,
+  SILENT_ABOVE_SPEED,
+} from '@/components/video-page/hooks/video-player-utils';
 import type { BunnyPlaybackState, BunnyQualityOption } from '@/components/video-page/types';
 
 interface BunnyPreviewPlayerProps {
@@ -34,8 +38,6 @@ export interface BunnyPreviewPlayerHandle {
   seekBy: (seconds: number) => void;
   toggleMute: () => void;
 }
-
-const SPEED_OPTIONS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 
 function formatTime(value: number): string {
   if (!Number.isFinite(value) || value < 0) return '0:00';
@@ -635,9 +637,14 @@ export const BunnyPreviewPlayer = forwardRef<BunnyPreviewPlayerHandle, BunnyPrev
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
-                  {SPEED_OPTIONS.map((speed) => (
+                  {NATIVE_SPEED_OPTIONS.map((speed) => (
                     <DropdownMenuItem key={speed} onClick={() => handleSpeedChange(speed)}>
                       {speed}x {speed === playbackSpeed ? '(Current)' : ''}
+                      {speed > SILENT_ABOVE_SPEED && (
+                        <span className="ml-auto pl-2 text-[10px] text-muted-foreground">
+                          no audio
+                        </span>
+                      )}
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuContent>

--- a/components/video-page/hooks/video-player-utils.ts
+++ b/components/video-page/hooks/video-player-utils.ts
@@ -95,6 +95,23 @@ export function timeFromClientX(
   return percentage * duration;
 }
 
+// Speed ladders. YouTube is played through its iframe API, which silently
+// ignores any rate outside the list `getAvailablePlaybackRates()` returns, so
+// 2x is the ceiling there. Bunny and R2 are plain <video> elements, where the
+// ceiling is the browser's: Chrome and Firefox both clamp `playbackRate` at 16,
+// and setting more throws, so 16x is the top of the ladder.
+export const YOUTUBE_SPEED_OPTIONS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
+export const NATIVE_SPEED_OPTIONS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 6, 8, 16];
+
+// Past 4x the browsers stop pitch-correcting and drop the audio track entirely.
+// The video still plays, so the fast rates are worth offering, but the picker
+// says so rather than letting a silent 8x read as a broken file.
+export const SILENT_ABOVE_SPEED = 4;
+
+export function getSpeedOptionsForProvider(providerId: string | null | undefined): number[] {
+  return providerId === 'youtube' ? YOUTUBE_SPEED_OPTIONS : NATIVE_SPEED_OPTIONS;
+}
+
 /**
  * Next or previous entry in the speed ladder, or `null` at either end. An
  * unknown current speed behaves like index -1, so stepping up lands on the

--- a/components/video-page/player-core.tsx
+++ b/components/video-page/player-core.tsx
@@ -31,6 +31,7 @@ import {
   type AnnotationCanvasHandle,
   type AnnotationStroke,
 } from '@/components/annotation-canvas';
+import { SILENT_ABOVE_SPEED } from '@/components/video-page/hooks/video-player-utils';
 import type { BunnyQualityOption, CommentMarker } from '@/components/video-page/types';
 
 interface PlayerCoreProps {
@@ -453,9 +454,17 @@ export const PlayerCore = memo(function PlayerCore({
                   <DropdownMenuItem
                     key={speed}
                     onClick={() => handleSpeedChange(speed)}
-                    className={cn(speed === playbackSpeed && 'font-bold text-primary')}
+                    className={cn(
+                      'flex items-center justify-between gap-2',
+                      speed === playbackSpeed && 'font-bold text-primary'
+                    )}
                   >
                     {speed}x
+                    {speed > SILENT_ABOVE_SPEED && (
+                      <span className="text-[10px] font-normal text-muted-foreground">
+                        no audio
+                      </span>
+                    )}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>

--- a/tests/unit/video-player-utils.test.ts
+++ b/tests/unit/video-player-utils.test.ts
@@ -6,11 +6,15 @@ import {
   getFrameStepLabel,
   getFrameStepSeconds,
   getPlayheadPercent,
+  getSpeedOptionsForProvider,
   isTypingTarget,
   normalizeFrameRate,
+  NATIVE_SPEED_OPTIONS,
   resolvePlayerShortcut,
   resolveSkipAmount,
+  SILENT_ABOVE_SPEED,
   timeFromClientX,
+  YOUTUBE_SPEED_OPTIONS,
 } from '@/components/video-page/hooks/video-player-utils';
 
 const SPEEDS = [0.25, 0.5, 1, 1.5, 2];
@@ -212,6 +216,34 @@ describe('getAdjacentPlaybackSpeed', () => {
   it('returns null for an empty ladder', () => {
     expect(getAdjacentPlaybackSpeed([], 1, 1)).toBeNull();
     expect(getAdjacentPlaybackSpeed([], 1, -1)).toBeNull();
+  });
+});
+
+describe('getSpeedOptionsForProvider', () => {
+  it('caps YouTube at 2x, since its iframe API ignores anything faster', () => {
+    expect(getSpeedOptionsForProvider('youtube')).toBe(YOUTUBE_SPEED_OPTIONS);
+    expect(Math.max(...YOUTUBE_SPEED_OPTIONS)).toBe(2);
+  });
+
+  it('lets the <video> providers run up to the browser ceiling', () => {
+    for (const provider of ['bunny', 'r2', undefined, null]) {
+      expect(getSpeedOptionsForProvider(provider)).toBe(NATIVE_SPEED_OPTIONS);
+    }
+    expect(NATIVE_SPEED_OPTIONS).toContain(3);
+    // 16 is where Chrome and Firefox clamp `playbackRate`; anything past it throws.
+    expect(Math.max(...NATIVE_SPEED_OPTIONS)).toBe(16);
+  });
+
+  it('marks the rates the browser plays without audio', () => {
+    expect(SILENT_ABOVE_SPEED).toBe(4);
+    expect(NATIVE_SPEED_OPTIONS.filter((speed) => speed > SILENT_ABOVE_SPEED)).toEqual([6, 8, 16]);
+    expect(YOUTUBE_SPEED_OPTIONS.every((speed) => speed <= SILENT_ABOVE_SPEED)).toBe(true);
+  });
+
+  it('keeps both ladders ascending so the arrow-key stepping stays monotonic', () => {
+    for (const ladder of [YOUTUBE_SPEED_OPTIONS, NATIVE_SPEED_OPTIONS]) {
+      expect([...ladder].sort((a, b) => a - b)).toEqual(ladder);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Playback speed is no longer capped at 2x on Bunny and R2. The speed ladder is now picked per provider:

- YouTube keeps `0.25x - 2x`.
- Bunny and R2 get `0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 6, 8, 16`.

Both the speed dropdown and the arrow-key stepping read the same ladder, so they stay in sync. Rates past 4x are labelled `no audio` in the picker: that is where Chrome and Firefox stop pitch-correcting and drop the audio track, and a silently playing 8x would otherwise read as a broken file. 16x is the top because both browsers clamp `playbackRate` there.

## Why

`SPEED_OPTIONS` was a single module-level constant in `video-page-content.tsx`, shared by every provider. YouTube versions play through the iframe API, which silently ignores any rate outside what `getAvailablePlaybackRates()` returns, so the ladder had to stop at 2x for YouTube to work. Bunny and R2 are plain `<video>` elements whose `playbackRate` the browser honours well past that, but they inherited YouTube's ceiling for no reason.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [x] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [ ] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check
  eslint --max-warnings=0        ok
  prettier --check .             ok
  tsc --noEmit                   ok

vitest run --project unit --project component video-player-utils use-video-player
  tests/unit/video-player-utils.test.ts       39 passed
  tests/component/hooks/use-video-player.test.ts  29 passed

Not manually exercised in a browser: the 6x/8x/16x rates and the
"no audio" labelling are covered by unit tests over the ladder only.
```

## Breaking changes

- [x] No breaking changes

## Database / migration notes

None.
