### PR TITLE
fix(player): label only 16x as silent in the speed picker

### DIFF
--- a/components/video-page/hooks/video-player-utils.ts
+++ b/components/video-page/hooks/video-player-utils.ts
@@ -103,10 +103,11 @@ export function timeFromClientX(
 export const YOUTUBE_SPEED_OPTIONS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2];
 export const NATIVE_SPEED_OPTIONS = [0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5, 3, 4, 6, 8, 16];
 
-// Past 4x the browsers stop pitch-correcting and drop the audio track entirely.
-// The video still plays, so the fast rates are worth offering, but the picker
-// says so rather than letting a silent 8x read as a broken file.
-export const SILENT_ABOVE_SPEED = 4;
+// The browsers keep the audio track well past the point where they stop
+// pitch-correcting: playback is still audible at 8x, and only the 16x clamp is
+// silent. The video plays either way, so the rate stays on the ladder and the
+// picker labels it rather than letting a silent 16x read as a broken file.
+export const SILENT_ABOVE_SPEED = 8;
 
 export function getSpeedOptionsForProvider(providerId: string | null | undefined): number[] {
   return providerId === 'youtube' ? YOUTUBE_SPEED_OPTIONS : NATIVE_SPEED_OPTIONS;

--- a/tests/unit/video-player-utils.test.ts
+++ b/tests/unit/video-player-utils.test.ts
@@ -235,8 +235,9 @@ describe('getSpeedOptionsForProvider', () => {
   });
 
   it('marks the rates the browser plays without audio', () => {
-    expect(SILENT_ABOVE_SPEED).toBe(4);
-    expect(NATIVE_SPEED_OPTIONS.filter((speed) => speed > SILENT_ABOVE_SPEED)).toEqual([6, 8, 16]);
+    // Measured in the browser: 6x and 8x still carry audio, 16x is the only silent rate.
+    expect(SILENT_ABOVE_SPEED).toBe(8);
+    expect(NATIVE_SPEED_OPTIONS.filter((speed) => speed > SILENT_ABOVE_SPEED)).toEqual([16]);
     expect(YOUTUBE_SPEED_OPTIONS.every((speed) => speed <= SILENT_ABOVE_SPEED)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

The speed picker tagged every rate past 4x with a "no audio" note. Only 16x is actually silent, so the threshold moves from 4 to 8 and the note now appears on that one entry.

## Why

The threshold was a guess about where the browsers stop pitch-correcting. Playing the ladder through shows audio survives 6x and 8x, and drops only at 16x, the rate Chrome and Firefox clamp `playbackRate` to. Two usable rates were advertising themselves as broken.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [x] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [x] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [x] I used `successResponse` / `apiErrors` for API response changes.
- [x] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [x] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun test tests/unit/video-player-utils.test.ts
 39 pass / 0 fail (137 expect() calls)

bun run check
 eslint --max-warnings=0: clean
 prettier --check: all matched files use Prettier code style
 tsc --noEmit: clean

Manual: stepped a Bunny-hosted video through the whole native ladder.
Audio plays at 6x and 8x, goes away at 16x.
```

## Breaking changes

- [x] No breaking changes
- [ ] This PR introduces a breaking change (describe below)