### PR TITLE
chore(comments): drop the image paste hint from the composer

### DIFF
--- a/components/video-page/comment-composer.tsx
+++ b/components/video-page/comment-composer.tsx
@@ -395,9 +395,7 @@ export const CommentComposer = memo(function CommentComposer({
               )}
             </div>
           </div>
-          <p className="text-xs text-muted-foreground mt-2">
-            Cmd+Enter to submit &middot; paste or drop up to {MAX_COMMENT_IMAGES} images
-          </p>
+          <p className="text-xs text-muted-foreground mt-2">Cmd+Enter to submit</p>
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary

Removes the "paste or drop up to N images" hint under the comment composer. The helper line now only says `Cmd+Enter to submit`.

## Why

The hint was redundant: the attachment button next to it already carries the same information in its tooltip (`Attach images (up to 5)`), and pasting/dropping keeps working exactly as before.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [x] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [ ] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check (podman, oven/bun:alpine): lint + format:check + typecheck all pass.
Not manually clicked through in the browser; the change is a static text node with no logic attached.
```

## Breaking changes

- [x] No breaking changes

## Database / migration notes

None.

## Screenshots / examples (if relevant)

None.
