### PR TITLE
chore(release): set the package version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openframe",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Sets `package.json` to `0.1.1`, the version that is already tagged and published.

## Why

`v0.1.1` ships the runtime Bunny CDN configuration from #66, but the manifest still read `0.1.0`, which is what `v0.1.0` shipped. Nothing reads this value at runtime, so this is bookkeeping: it keeps the tag and the manifest from drifting further apart.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [ ] UI / UX
- [ ] Documentation
- [x] Other (release metadata)

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [x] I used `successResponse` / `apiErrors` for API response changes.
- [x] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [x] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun install --frozen-lockfile   Checked 1198 installs across 1208 packages (no changes)
```

`bun.lock` records no version for the root workspace, so the frozen install the Dockerfile and CI run is unaffected and the lockfile needs no update.

## Breaking changes

- [x] No breaking changes
- [ ] This PR introduces a breaking change (describe below)

## Database / migration notes

None.

## Screenshots / examples (if relevant)

None.
