### PR TITLE
feat(landing): remove the Fair Source badge from the hero

### DIFF
--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -231,17 +231,6 @@ export function LandingPage({ isLoggedIn }: LandingPageProps) {
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_var(--tw-gradient-stops))] from-primary/5 via-background to-background" />
 
           <div className="relative z-10 mx-auto max-w-[1000px] space-y-8">
-            <div
-              data-hero-copy
-              className="inline-flex items-center gap-2 border border-border/50 bg-secondary/30 px-3 py-1.5 text-xs text-muted-foreground backdrop-blur-md"
-            >
-              <span className="relative flex h-2 w-2">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-75"></span>
-                <span className="relative inline-flex h-2 w-2 rounded-full bg-primary"></span>
-              </span>
-              <span className="font-mono tracking-wide uppercase">Fair Source Video Review</span>
-            </div>
-
             <h1
               data-hero-copy
               className="text-4xl font-semibold leading-[0.95] tracking-[-0.03em] sm:text-5xl md:text-6xl lg:text-7xl"


### PR DESCRIPTION
## Summary

Removes the "Fair Source Video Review" pill badge above the hero headline on the landing page.

## Why

The badge is no longer wanted in the hero section.

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [x] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [x] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [x] I manually tested affected flows.
- [x] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [x] I updated docs when behavior changed.
- [x] No secrets or unrelated file changes are included.

Validation notes:

```text
bun run check: lint, format:check and typecheck all pass.
Pre-push hook ran vitest: 64 files, 2415 tests passed.
```

## Breaking changes

- [x] No breaking changes
- [ ] This PR introduces a breaking change (describe below)

## Database / migration notes

None.

## Screenshots / examples (if relevant)

Markup-only removal of the badge div in `components/LandingPage.tsx`.