### PR TITLE
feat: add internal review API, transcripts, and NLE marker sync

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -15,12 +15,17 @@ POSTGRES_PASSWORD="replace-with-strong-postgres-password"
 DATABASE_URL="postgresql://replace-with-postgres-user:replace-with-strong-postgres-password@postgres:5432/openframe?schema=public"
 NODE_ENV="production"
 
-# Self-host defaults
+# Self-host defaults (internal deployment)
 OPENFRAME_ENABLE_STRIPE="false"
 OPENFRAME_ENABLE_BUNNY_UPLOADS="false"
 OPENFRAME_ENABLE_S3_VIDEO_UPLOADS="true"
-# OPENFRAME_MAX_VIDEO_UPLOAD_BYTES="5368709120"
-OPENFRAME_REQUIRE_INVITE_CODE="false"
+# With Stripe off there is no account quota, so this MUST be set or uploads
+# are capped at a flat 5 GiB. 100 GiB in bytes:
+OPENFRAME_MAX_VIDEO_UPLOAD_BYTES="107374182400"
+OPENFRAME_REQUIRE_INVITE_CODE="true"
+OPENFRAME_ENABLE_ANALYTICS="false"
+OPENFRAME_ENABLE_TRANSCRIPTION="true"
+OPENFRAME_TRANSCRIPTION_PROVIDER="whisper-local"
 SELF_HOSTED_AUTO_CREATE_BUCKET="true"
 
 # Project bulk-download manifest limits (GET /api/projects/[projectId]/download).
@@ -51,7 +56,7 @@ R2_BUCKET_NAME="openframe"
 
 # Optional auth/admin configuration
 ADMIN_EMAILS=""
-INVITE_CODE=""
+INVITE_CODE="replace-with-a-strong-invite-code"
 
 # Optional integrations. Leave blank to disable.
 GOOGLE_CLIENT_ID=""

--- a/.env.example
+++ b/.env.example
@@ -26,8 +26,14 @@ OPENFRAME_ENABLE_S3_VIDEO_UPLOADS="false"
 # billed instance: the ceiling is then 80% of the account's own storage quota,
 # leaving room for the renditions the provider derives from the file. When set,
 # the lower of the two applies. Instances running without billing have no quota
-# to divide and fall back to 5 GiB.
-# OPENFRAME_MAX_VIDEO_UPLOAD_BYTES="5368709120"
+# to divide and fall back to 5 GiB — set this explicitly for an internal host.
+OPENFRAME_MAX_VIDEO_UPLOAD_BYTES="107374182400"
+# Transcription after a version is created. whisper-local runs on the media
+# worker; deepgram and openai send audio to those APIs.
+OPENFRAME_ENABLE_TRANSCRIPTION="true"
+OPENFRAME_TRANSCRIPTION_PROVIDER="whisper-local"
+# DEEPGRAM_API_KEY=""
+# OPENAI_API_KEY=""
 # Files larger than this use chunked (S3 multipart) uploads instead of a single PUT.
 # Default 90MiB keeps each request under the common 100MB Cloudflare proxy/tunnel cap.
 # Lower it if your proxy enforces a stricter request-body limit.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 
 # dependencies
 /node_modules
+worker/node_modules
+nle/**/node_modules
 /.pnp
 .pnp.*
 .yarn/*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,7 @@
 .next/
 node_modules/
+worker/
+nle/
 prisma/migrations/
 bun.lock
 coverage/

--- a/INTERNAL.md
+++ b/INTERNAL.md
@@ -1,0 +1,54 @@
+# Internal deployment
+
+This fork is for **internal use only**. OpenFrame’s Functional Source License
+(FSL-1.1-ALv2) permits internal use and modification. Do not sell this, host it
+as a public product, or use the OpenFrame name or marks on anything
+public-facing. Give the deployment your own name.
+
+## Upstream rebase
+
+The `upstream` remote points at `https://github.com/yusufipk/OpenFrame.git`.
+Rebase this branch onto upstream monthly so custom work stays close to theirs.
+
+```bash
+git fetch upstream
+git rebase upstream/master
+```
+
+Keep custom work **additive**: new files under `app/api/v1/`, `lib/timecode.ts`,
+`lib/api-token.ts`, `lib/transcription/`, `worker/`, and `nle/` rebase cleanly.
+Avoid editing upstream files except for the Prisma schema, the video-page side
+rail (one extra tab), the comment export format switch, and this env template.
+
+`worker/` and `nle/` are independent packages with their own lockfiles. Do not
+turn the repo into a Bun workspace: that would make the root `bun.lock` a
+workspace lockfile and conflict on every upstream dependency bump.
+
+## Required env for an internal host
+
+Copy `.env.docker.example` to `.env.docker` and set real secrets. The values
+that matter for this fork:
+
+| Variable                                    | Value                                              | Why                                                                                                        |
+| ------------------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `OPENFRAME_ENABLE_STRIPE`                   | `false`                                            | Billing is wired into authorization. Off, every account has access and no trial caps apply.                |
+| `OPENFRAME_MAX_VIDEO_UPLOAD_BYTES`          | set explicitly (default 100 GiB in the example)    | With Stripe off there is no quota, so the code falls back to a flat **5 GiB** per file unless this is set. |
+| `OPENFRAME_ENABLE_S3_VIDEO_UPLOADS`         | `true`                                             | Direct uploads to bundled MinIO.                                                                           |
+| `OPENFRAME_ENABLE_BUNNY_UPLOADS`            | `false`                                            | Only one direct-upload backend can be active.                                                              |
+| `OPENFRAME_REQUIRE_INVITE_CODE`             | `true`                                             | Registration stays closed. Set `INVITE_CODE`.                                                              |
+| `OPENFRAME_ENABLE_ANALYTICS`                | `false`                                            | Leave the marketing funnel off.                                                                            |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | your Workspace OAuth app                           | SSO for the company domain. Restrict the OAuth client to your domain in Google Cloud.                      |
+| `OPENFRAME_ENABLE_TRANSCRIPTION`            | `true`                                             | Enqueue transcription after a version lands.                                                               |
+| `OPENFRAME_TRANSCRIPTION_PROVIDER`          | `whisper-local` (default), `deepgram`, or `openai` | Pluggable. Cloud providers need their API keys.                                                            |
+
+## Services
+
+`docker compose up --build` starts:
+
+- the Next.js app
+- PostgreSQL
+- MinIO
+- the media worker (ffmpeg + job poller)
+
+The worker probes uploaded files for a rational frame rate and, when
+transcription is enabled, extracts audio and transcribes it.

--- a/app/(dashboard)/settings/settings-page-client.tsx
+++ b/app/(dashboard)/settings/settings-page-client.tsx
@@ -7,6 +7,7 @@ import {
   Mail,
   CheckCircle2,
   AlertCircle,
+  Key,
   Loader2,
   Globe,
   CreditCard,
@@ -150,6 +151,18 @@ export default function SettingsPage({ billingOnly = false }: { billingOnly?: bo
   const [billingAction, setBillingAction] = useState<'checkout' | 'portal' | null>(null);
   const [storageInfo, setStorageInfo] = useState<StorageInfo | null>(null);
   const [storageLoading, setStorageLoading] = useState(true);
+  const [apiTokens, setApiTokens] = useState<
+    Array<{
+      id: string;
+      name: string;
+      tokenPrefix: string;
+      lastUsedAt: string | null;
+      createdAt: string;
+    }>
+  >([]);
+  const [newTokenName, setNewTokenName] = useState('NLE panel');
+  const [createdTokenSecret, setCreatedTokenSecret] = useState<string | null>(null);
+  const [tokenBusy, setTokenBusy] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   // Form state for Telegram chat ID (separate from saved settings for editing)
@@ -162,10 +175,11 @@ export default function SettingsPage({ billingOnly = false }: { billingOnly?: bo
   useEffect(() => {
     async function fetchSettings() {
       try {
-        const [settingsRes, billingRes, storageRes] = await Promise.all([
+        const [settingsRes, billingRes, storageRes, tokensRes] = await Promise.all([
           fetch('/api/settings/notifications'),
           fetch('/api/billing'),
           fetch('/api/settings/storage'),
+          fetch('/api/settings/api-tokens'),
         ]);
 
         if (settingsRes.ok) {
@@ -182,6 +196,11 @@ export default function SettingsPage({ billingOnly = false }: { billingOnly?: bo
         if (storageRes.ok) {
           const data = await storageRes.json();
           setStorageInfo(data.data);
+        }
+
+        if (tokensRes.ok) {
+          const data = await tokensRes.json();
+          setApiTokens(data.data.tokens ?? []);
         }
       } catch {
         console.error('Failed to fetch settings');
@@ -811,6 +830,100 @@ export default function SettingsPage({ billingOnly = false }: { billingOnly?: bo
                   </SelectGroup>
                 </SelectContent>
               </Select>
+            </CardContent>
+          </Card>
+
+          <Separator className="my-6" />
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Key className="h-5 w-5" />
+                API tokens
+              </CardTitle>
+              <CardDescription>
+                Paste a token into the Premiere or Resolve panel. The secret is shown once.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex gap-2">
+                <Input
+                  value={newTokenName}
+                  onChange={(event) => setNewTokenName(event.target.value)}
+                  placeholder="Token name"
+                />
+                <Button
+                  disabled={tokenBusy || !newTokenName.trim()}
+                  onClick={async () => {
+                    setTokenBusy(true);
+                    try {
+                      const res = await fetch('/api/settings/api-tokens', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ name: newTokenName.trim() }),
+                      });
+                      const data = await res.json();
+                      if (!res.ok) {
+                        showMessage('error', data.error || 'Failed to create token');
+                        return;
+                      }
+                      setCreatedTokenSecret(data.data.token.secret);
+                      setApiTokens((current) => [
+                        {
+                          id: data.data.token.id,
+                          name: data.data.token.name,
+                          tokenPrefix: data.data.token.tokenPrefix,
+                          lastUsedAt: null,
+                          createdAt: data.data.token.createdAt,
+                        },
+                        ...current,
+                      ]);
+                    } finally {
+                      setTokenBusy(false);
+                    }
+                  }}
+                >
+                  Create
+                </Button>
+              </div>
+              {createdTokenSecret && (
+                <div className="rounded-md border bg-muted/40 p-3 text-sm break-all">
+                  <p className="font-medium mb-1">Copy this now. It will not be shown again.</p>
+                  <code>{createdTokenSecret}</code>
+                </div>
+              )}
+              <ul className="space-y-2">
+                {apiTokens.map((token) => (
+                  <li key={token.id} className="flex items-center justify-between gap-2 text-sm">
+                    <span>
+                      {token.name}{' '}
+                      <span className="text-muted-foreground">{token.tokenPrefix}…</span>
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={async () => {
+                        setTokenBusy(true);
+                        try {
+                          const res = await fetch(`/api/settings/api-tokens/${token.id}`, {
+                            method: 'DELETE',
+                          });
+                          if (res.ok) {
+                            setApiTokens((current) => current.filter((row) => row.id !== token.id));
+                          }
+                        } finally {
+                          setTokenBusy(false);
+                        }
+                      }}
+                    >
+                      Revoke
+                    </Button>
+                  </li>
+                ))}
+                {apiTokens.length === 0 && (
+                  <li className="text-sm text-muted-foreground">No active tokens.</li>
+                )}
+              </ul>
             </CardContent>
           </Card>
 

--- a/app/api/projects/[projectId]/videos/[videoId]/versions/route.ts
+++ b/app/api/projects/[projectId]/videos/[videoId]/versions/route.ts
@@ -9,6 +9,7 @@ import { readBunnyUploadGrant } from '@/lib/bunny-upload-token';
 import { finalizeR2VideoUpload } from '@/lib/r2-video-finalize';
 import { UPLOAD_RESERVATION_PURPOSES } from '@/lib/storage-quota';
 import { logError } from '@/lib/logger';
+import { enqueueJobsForNewVersion } from '@/lib/media-jobs';
 
 type RouteParams = { params: Promise<{ projectId: string; videoId: string }> };
 
@@ -291,6 +292,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     const response = successResponse(version, 201);
+    await enqueueJobsForNewVersion({
+      versionId: version.id,
+      providerId: version.providerId,
+    }).catch((err) => logError('Failed to enqueue media jobs:', err));
     return withCacheControl(response, 'private, no-store');
   } catch (error) {
     logError('Error creating version:', error);

--- a/app/api/projects/[projectId]/videos/route.ts
+++ b/app/api/projects/[projectId]/videos/route.ts
@@ -10,6 +10,7 @@ import { finalizeR2VideoUpload } from '@/lib/r2-video-finalize';
 import { UPLOAD_RESERVATION_PURPOSES } from '@/lib/storage-quota';
 import { logError } from '@/lib/logger';
 import { eventKey, recordEvent } from '@/lib/analytics/record';
+import { enqueueJobsForNewVersion } from '@/lib/media-jobs';
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
@@ -303,6 +304,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       dedupeKey: eventKey('VIDEO_ADDED', video.id),
       userId: project.ownerId,
     });
+
+    const firstVersion = video.versions[0];
+    if (firstVersion) {
+      await enqueueJobsForNewVersion({
+        versionId: firstVersion.id,
+        providerId: firstVersion.providerId,
+      }).catch((err) => logError('Failed to enqueue media jobs:', err));
+    }
 
     const response = successResponse(video, 201);
     return withCacheControl(response, 'private, no-store');

--- a/app/api/settings/api-tokens/[tokenId]/route.ts
+++ b/app/api/settings/api-tokens/[tokenId]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/lib/db';
+import { auth } from '@/lib/auth';
+import { rateLimit } from '@/lib/rate-limit';
+import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
+import { logError } from '@/lib/logger';
+
+type RouteParams = { params: Promise<{ tokenId: string }> };
+
+export async function DELETE(request: NextRequest, { params }: RouteParams) {
+  try {
+    const limited = await rateLimit(request, 'mutate');
+    if (limited) return limited;
+
+    const session = await auth();
+    if (!session?.user?.id) return apiErrors.unauthorized();
+
+    const { tokenId } = await params;
+    const updated = await db.apiToken.updateMany({
+      where: { id: tokenId, userId: session.user.id, revokedAt: null },
+      data: { revokedAt: new Date() },
+    });
+
+    if (updated.count !== 1) {
+      return apiErrors.notFound('API token');
+    }
+
+    return withCacheControl(successResponse({ ok: true }), 'private, no-store');
+  } catch (error) {
+    logError('Error revoking API token:', error);
+    return apiErrors.internalError('Failed to revoke API token');
+  }
+}

--- a/app/api/settings/api-tokens/route.ts
+++ b/app/api/settings/api-tokens/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/lib/db';
+import { auth } from '@/lib/auth';
+import { rateLimit } from '@/lib/rate-limit';
+import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
+import { generateApiToken } from '@/lib/api-token';
+import { logError } from '@/lib/logger';
+
+const MAX_TOKENS_PER_USER = 20;
+const MAX_NAME_LENGTH = 60;
+
+export async function GET() {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) return apiErrors.unauthorized();
+
+    const tokens = await db.apiToken.findMany({
+      where: { userId: session.user.id, revokedAt: null },
+      orderBy: { createdAt: 'desc' },
+      select: {
+        id: true,
+        name: true,
+        tokenPrefix: true,
+        lastUsedAt: true,
+        expiresAt: true,
+        createdAt: true,
+      },
+    });
+
+    return withCacheControl(successResponse({ tokens }), 'private, no-store');
+  } catch (error) {
+    logError('Error listing API tokens:', error);
+    return apiErrors.internalError('Failed to list API tokens');
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const limited = await rateLimit(request, 'mutate');
+    if (limited) return limited;
+
+    const session = await auth();
+    if (!session?.user?.id) return apiErrors.unauthorized();
+
+    const body = await request.json().catch(() => null);
+    const name = typeof body?.name === 'string' ? body.name.trim() : '';
+    if (!name || name.length > MAX_NAME_LENGTH) {
+      return apiErrors.badRequest(
+        `Name is required and must be at most ${MAX_NAME_LENGTH} characters`
+      );
+    }
+
+    const existing = await db.apiToken.count({
+      where: { userId: session.user.id, revokedAt: null },
+    });
+    if (existing >= MAX_TOKENS_PER_USER) {
+      return apiErrors.badRequest(`At most ${MAX_TOKENS_PER_USER} active tokens per user`);
+    }
+
+    const generated = generateApiToken();
+    const row = await db.apiToken.create({
+      data: {
+        userId: session.user.id,
+        name,
+        tokenHash: generated.hash,
+        tokenPrefix: generated.prefix,
+      },
+      select: { id: true, name: true, tokenPrefix: true, createdAt: true },
+    });
+
+    return withCacheControl(
+      successResponse({ token: { ...row, secret: generated.raw } }, 201),
+      'private, no-store'
+    );
+  } catch (error) {
+    logError('Error creating API token:', error);
+    return apiErrors.internalError('Failed to create API token');
+  }
+}

--- a/app/api/v1/comments/[commentId]/route.ts
+++ b/app/api/v1/comments/[commentId]/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/lib/db';
+import { rateLimit } from '@/lib/rate-limit';
+import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
+import { isAuthError, loadVersionForUser, withApiAuth } from '@/lib/v1-auth';
+import { logError } from '@/lib/logger';
+
+type RouteParams = { params: Promise<{ commentId: string }> };
+
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const limited = await rateLimit(request, 'comment');
+    if (limited) return limited;
+
+    const authContext = await withApiAuth(request);
+    if (isAuthError(authContext)) return authContext;
+
+    const { commentId } = await params;
+    const comment = await db.comment.findUnique({
+      where: { id: commentId },
+      select: { id: true, versionId: true, isResolved: true },
+    });
+    if (!comment) return apiErrors.notFound('Comment');
+
+    const loaded = await loadVersionForUser(comment.versionId, authContext.userId);
+    if ('error' in loaded) return loaded.error;
+    if (!loaded.access.canEdit && !loaded.access.hasAccess) {
+      return apiErrors.forbidden('Access denied');
+    }
+
+    const body = await request.json().catch(() => null);
+    const data: { isResolved?: boolean; resolvedAt?: Date | null; content?: string } = {};
+
+    if (typeof body?.isResolved === 'boolean') {
+      data.isResolved = body.isResolved;
+      data.resolvedAt = body.isResolved ? new Date() : null;
+    }
+    if (typeof body?.content === 'string') {
+      data.content = body.content.trim();
+    }
+
+    if (Object.keys(data).length === 0) {
+      return apiErrors.badRequest('Provide isResolved and/or content');
+    }
+
+    const updated = await db.comment.update({
+      where: { id: commentId },
+      data,
+      select: {
+        id: true,
+        content: true,
+        timestamp: true,
+        timestampEnd: true,
+        timestampFrame: true,
+        isResolved: true,
+        resolvedAt: true,
+        parentId: true,
+        updatedAt: true,
+      },
+    });
+
+    return withCacheControl(successResponse({ comment: updated }), 'private, no-store');
+  } catch (error) {
+    logError('Error updating v1 comment:', error);
+    return apiErrors.internalError('Failed to update comment');
+  }
+}

--- a/app/api/v1/projects/[projectId]/videos/route.ts
+++ b/app/api/v1/projects/[projectId]/videos/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/lib/db';
+import { rateLimit } from '@/lib/rate-limit';
+import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
+import { isAuthError, loadProjectForUser, withApiAuth } from '@/lib/v1-auth';
+import { logError } from '@/lib/logger';
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const limited = await rateLimit(request, 'api-v1');
+    if (limited) return limited;
+
+    const authContext = await withApiAuth(request);
+    if (isAuthError(authContext)) return authContext;
+
+    const { projectId } = await params;
+    const loaded = await loadProjectForUser(projectId, authContext.userId);
+    if ('error' in loaded) return loaded.error;
+
+    const videos = await db.video.findMany({
+      where: { projectId },
+      orderBy: { position: 'asc' },
+      select: {
+        id: true,
+        title: true,
+        position: true,
+        updatedAt: true,
+        versions: {
+          orderBy: { versionNumber: 'desc' },
+          select: {
+            id: true,
+            versionNumber: true,
+            versionLabel: true,
+            isActive: true,
+            duration: true,
+            frameRateNum: true,
+            frameRateDen: true,
+            dropFrame: true,
+            startTimecode: true,
+            durationFrames: true,
+          },
+        },
+      },
+    });
+
+    return withCacheControl(successResponse({ videos }), 'private, no-store');
+  } catch (error) {
+    logError('Error listing v1 videos:', error);
+    return apiErrors.internalError('Failed to list videos');
+  }
+}

--- a/app/api/v1/projects/route.ts
+++ b/app/api/v1/projects/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/lib/db';
+import { rateLimit } from '@/lib/rate-limit';
+import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
+import { isAuthError, withApiAuth } from '@/lib/v1-auth';
+import { logError } from '@/lib/logger';
+
+export async function GET(request: NextRequest) {
+  try {
+    const limited = await rateLimit(request, 'api-v1');
+    if (limited) return limited;
+
+    const authContext = await withApiAuth(request);
+    if (isAuthError(authContext)) return authContext;
+
+    const memberships = await db.workspaceMember.findMany({
+      where: { userId: authContext.userId },
+      select: { workspaceId: true },
+    });
+    const memberWorkspaceIds = memberships.map((row) => row.workspaceId);
+
+    const projects = await db.project.findMany({
+      where: {
+        OR: [
+          { ownerId: authContext.userId },
+          { members: { some: { userId: authContext.userId } } },
+          { workspaceId: { in: memberWorkspaceIds } },
+        ],
+      },
+      orderBy: { updatedAt: 'desc' },
+      select: {
+        id: true,
+        name: true,
+        slug: true,
+        workspaceId: true,
+        updatedAt: true,
+        _count: { select: { videos: true } },
+      },
+      take: 200,
+    });
+
+    return withCacheControl(successResponse({ projects }), 'private, no-store');
+  } catch (error) {
+    logError('Error listing v1 projects:', error);
+    return apiErrors.internalError('Failed to list projects');
+  }
+}

--- a/app/api/v1/versions/[versionId]/comments/route.ts
+++ b/app/api/v1/versions/[versionId]/comments/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/lib/db';
+import { rateLimit } from '@/lib/rate-limit';
+import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
+import { isAuthError, loadVersionForUser, withApiAuth } from '@/lib/v1-auth';
+import { deriveTimestampFrame } from '@/lib/timecode';
+import { logError } from '@/lib/logger';
+
+type RouteParams = { params: Promise<{ versionId: string }> };
+
+const COMMENT_SELECT = {
+  id: true,
+  content: true,
+  timestamp: true,
+  timestampEnd: true,
+  timestampFrame: true,
+  isResolved: true,
+  resolvedAt: true,
+  parentId: true,
+  authorId: true,
+  guestName: true,
+  tagId: true,
+  createdAt: true,
+  updatedAt: true,
+  author: { select: { id: true, name: true } },
+  tag: { select: { id: true, name: true, color: true } },
+} as const;
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const limited = await rateLimit(request, 'api-v1');
+    if (limited) return limited;
+
+    const authContext = await withApiAuth(request);
+    if (isAuthError(authContext)) return authContext;
+
+    const { versionId } = await params;
+    const loaded = await loadVersionForUser(versionId, authContext.userId);
+    if ('error' in loaded) return loaded.error;
+
+    const { searchParams } = new URL(request.url);
+    const includeResolved = searchParams.get('includeResolved') !== 'false';
+    const updatedSinceRaw = searchParams.get('updatedSince');
+    let updatedSince: Date | null = null;
+    if (updatedSinceRaw) {
+      const parsed = new Date(updatedSinceRaw);
+      if (Number.isNaN(parsed.getTime())) {
+        return apiErrors.badRequest('updatedSince must be an ISO-8601 timestamp');
+      }
+      updatedSince = parsed;
+    }
+
+    const comments = await db.comment.findMany({
+      where: {
+        versionId,
+        ...(includeResolved ? {} : { isResolved: false }),
+        ...(updatedSince ? { updatedAt: { gte: updatedSince } } : {}),
+      },
+      orderBy: { timestamp: 'asc' },
+      take: 5000,
+      select: COMMENT_SELECT,
+    });
+
+    return withCacheControl(successResponse({ comments }), 'private, no-store');
+  } catch (error) {
+    logError('Error listing v1 comments:', error);
+    return apiErrors.internalError('Failed to list comments');
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const limited = await rateLimit(request, 'comment');
+    if (limited) return limited;
+
+    const authContext = await withApiAuth(request);
+    if (isAuthError(authContext)) return authContext;
+
+    const { versionId } = await params;
+    const loaded = await loadVersionForUser(versionId, authContext.userId);
+    if ('error' in loaded) return loaded.error;
+
+    const body = await request.json().catch(() => null);
+    const content = typeof body?.content === 'string' ? body.content.trim() : '';
+    const timestamp =
+      typeof body?.timestamp === 'number' ? body.timestamp : Number(body?.timestamp);
+    const timestampEndRaw = body?.timestampEnd;
+    const timestampEnd =
+      timestampEndRaw === null || timestampEndRaw === undefined
+        ? null
+        : typeof timestampEndRaw === 'number'
+          ? timestampEndRaw
+          : Number(timestampEndRaw);
+
+    if (!Number.isFinite(timestamp) || timestamp < 0) {
+      return apiErrors.badRequest('timestamp is required and must be a non-negative number');
+    }
+    if (timestampEnd !== null && (!Number.isFinite(timestampEnd) || timestampEnd < timestamp)) {
+      return apiErrors.badRequest('timestampEnd must be greater than or equal to timestamp');
+    }
+    if (!content) {
+      return apiErrors.badRequest('content is required');
+    }
+
+    const version = loaded.version;
+    const comment = await db.comment.create({
+      data: {
+        content,
+        timestamp,
+        timestampEnd,
+        timestampFrame: deriveTimestampFrame(timestamp, version.frameRateNum, version.frameRateDen),
+        versionId,
+        authorId: authContext.userId,
+      },
+      select: COMMENT_SELECT,
+    });
+
+    return withCacheControl(successResponse({ comment }, 201), 'private, no-store');
+  } catch (error) {
+    logError('Error creating v1 comment:', error);
+    return apiErrors.internalError('Failed to create comment');
+  }
+}

--- a/app/api/v1/versions/[versionId]/route.ts
+++ b/app/api/v1/versions/[versionId]/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from 'next/server';
+import { rateLimit } from '@/lib/rate-limit';
+import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
+import { isAuthError, loadVersionForUser, withApiAuth } from '@/lib/v1-auth';
+import { logError } from '@/lib/logger';
+
+type RouteParams = { params: Promise<{ versionId: string }> };
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const limited = await rateLimit(request, 'api-v1');
+    if (limited) return limited;
+
+    const authContext = await withApiAuth(request);
+    if (isAuthError(authContext)) return authContext;
+
+    const { versionId } = await params;
+    const loaded = await loadVersionForUser(versionId, authContext.userId);
+    if ('error' in loaded) return loaded.error;
+
+    const { version } = loaded;
+    return withCacheControl(
+      successResponse({
+        version: {
+          id: version.id,
+          versionNumber: version.versionNumber,
+          versionLabel: version.versionLabel,
+          providerId: version.providerId,
+          duration: version.duration,
+          frameRateNum: version.frameRateNum,
+          frameRateDen: version.frameRateDen,
+          dropFrame: version.dropFrame,
+          startTimecode: version.startTimecode,
+          durationFrames: version.durationFrames,
+          isActive: version.isActive,
+          video: {
+            id: version.video.id,
+            title: version.video.title,
+            project: version.video.project,
+          },
+        },
+      }),
+      'private, no-store'
+    );
+  } catch (error) {
+    logError('Error fetching v1 version:', error);
+    return apiErrors.internalError('Failed to fetch version');
+  }
+}

--- a/app/api/v1/versions/[versionId]/transcript/route.ts
+++ b/app/api/v1/versions/[versionId]/transcript/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest } from 'next/server';
+import { db } from '@/lib/db';
+import { MediaJobKind, TranscriptStatus } from '@prisma/client';
+import { rateLimit } from '@/lib/rate-limit';
+import { apiErrors, successResponse, withCacheControl } from '@/lib/api-response';
+import { isAuthError, loadVersionForUser, withApiAuth } from '@/lib/v1-auth';
+import { enqueueMediaJob } from '@/lib/media-jobs';
+import { getTranscriptionProviderName, isTranscriptionFeatureEnabled } from '@/lib/feature-flags';
+import { logError } from '@/lib/logger';
+
+type RouteParams = { params: Promise<{ versionId: string }> };
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const limited = await rateLimit(request, 'api-v1');
+    if (limited) return limited;
+
+    const authContext = await withApiAuth(request);
+    if (isAuthError(authContext)) return authContext;
+
+    const { versionId } = await params;
+    const loaded = await loadVersionForUser(versionId, authContext.userId);
+    if ('error' in loaded) return loaded.error;
+
+    const { searchParams } = new URL(request.url);
+    const q = searchParams.get('q')?.trim() ?? '';
+
+    const transcript = await db.transcript.findFirst({
+      where: { versionId },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        segments: { orderBy: { position: 'asc' } },
+      },
+    });
+
+    if (!transcript) {
+      return withCacheControl(successResponse({ transcript: null }), 'private, no-store');
+    }
+
+    let segments = transcript.segments;
+    if (q) {
+      const lowered = q.toLowerCase();
+      segments = segments.filter((segment) => segment.text.toLowerCase().includes(lowered));
+    }
+
+    return withCacheControl(
+      successResponse({
+        transcript: {
+          id: transcript.id,
+          versionId: transcript.versionId,
+          language: transcript.language,
+          provider: transcript.provider,
+          status: transcript.status,
+          segments: segments.map((segment) => ({
+            id: segment.id,
+            startSec: segment.startSec,
+            endSec: segment.endSec,
+            speaker: segment.speaker,
+            text: segment.text,
+            words: segment.words,
+            position: segment.position,
+          })),
+        },
+      }),
+      'private, no-store'
+    );
+  } catch (error) {
+    logError('Error fetching v1 transcript:', error);
+    return apiErrors.internalError('Failed to fetch transcript');
+  }
+}
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const limited = await rateLimit(request, 'mutate');
+    if (limited) return limited;
+
+    const authContext = await withApiAuth(request);
+    if (isAuthError(authContext)) return authContext;
+
+    const { versionId } = await params;
+    const loaded = await loadVersionForUser(versionId, authContext.userId);
+    if ('error' in loaded) return loaded.error;
+    if (!loaded.access.canEdit) return apiErrors.forbidden('Access denied');
+
+    if (!isTranscriptionFeatureEnabled()) {
+      return apiErrors.badRequest('Transcription is disabled on this host');
+    }
+
+    const body = await request.json().catch(() => null);
+    const language = typeof body?.language === 'string' ? body.language.trim().toLowerCase() : 'en';
+
+    const transcript = await db.transcript.upsert({
+      where: { versionId_language: { versionId, language } },
+      create: {
+        versionId,
+        language,
+        provider: getTranscriptionProviderName(),
+        status: TranscriptStatus.PENDING,
+      },
+      update: {
+        status: TranscriptStatus.PENDING,
+        error: null,
+        provider: getTranscriptionProviderName(),
+      },
+    });
+
+    await enqueueMediaJob(versionId, MediaJobKind.EXTRACT_AUDIO);
+    await enqueueMediaJob(versionId, MediaJobKind.TRANSCRIBE, {
+      language,
+      transcriptId: transcript.id,
+    });
+
+    return withCacheControl(successResponse({ transcript }, 202), 'private, no-store');
+  } catch (error) {
+    logError('Error enqueueing transcript:', error);
+    return apiErrors.internalError('Failed to enqueue transcription');
+  }
+}

--- a/app/api/versions/[versionId]/comments/export/route.ts
+++ b/app/api/versions/[versionId]/comments/export/route.ts
@@ -3,6 +3,8 @@ import { auth, checkProjectAccess } from '@/lib/auth';
 import { db } from '@/lib/db';
 import {
   buildCommentsCsv,
+  buildCommentsEdl,
+  buildCommentsFcpxml,
   buildCommentsPdf,
   buildExportFileBaseName,
   flattenCommentsForExport,
@@ -29,8 +31,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     const { searchParams } = new URL(request.url);
 
     const format = (searchParams.get('format') || 'csv').toLowerCase();
-    if (format !== 'csv' && format !== 'pdf') {
-      return apiErrors.badRequest('Invalid format. Use "csv" or "pdf"');
+    if (format !== 'csv' && format !== 'pdf' && format !== 'edl' && format !== 'fcpxml') {
+      return apiErrors.badRequest('Invalid format. Use "csv", "pdf", "edl", or "fcpxml"');
     }
 
     const includeResolved = searchParams.get('includeResolved') !== 'false';
@@ -41,6 +43,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         id: true,
         versionNumber: true,
         versionLabel: true,
+        duration: true,
+        frameRateNum: true,
+        frameRateDen: true,
+        dropFrame: true,
+        startTimecode: true,
         video: {
           select: {
             title: true,
@@ -131,6 +138,19 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       versionNumber: version.versionNumber,
       versionLabel: version.versionLabel,
     };
+    const markerMeta = {
+      ...versionMeta,
+      frameRate:
+        version.frameRateNum && version.frameRateDen
+          ? {
+              num: version.frameRateNum,
+              den: version.frameRateDen,
+              dropFrame: version.dropFrame,
+            }
+          : null,
+      startTimecode: version.startTimecode,
+      durationSeconds: version.duration,
+    };
 
     if (format === 'csv') {
       const csv = buildCommentsCsv(rows, versionMeta);
@@ -142,6 +162,30 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
         },
       });
 
+      return withCacheControl(response, 'private, no-store');
+    }
+
+    if (format === 'edl') {
+      const edl = buildCommentsEdl(rows, markerMeta);
+      const response = new Response(edl, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'Content-Disposition': `attachment; filename="${fileBaseName}.edl"`,
+        },
+      });
+      return withCacheControl(response, 'private, no-store');
+    }
+
+    if (format === 'fcpxml') {
+      const xml = buildCommentsFcpxml(rows, markerMeta);
+      const response = new Response(xml, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/xml; charset=utf-8',
+          'Content-Disposition': `attachment; filename="${fileBaseName}.fcpxml"`,
+        },
+      });
       return withCacheControl(response, 'private, no-store');
     }
 

--- a/app/api/versions/[versionId]/comments/route.ts
+++ b/app/api/versions/[versionId]/comments/route.ts
@@ -27,6 +27,7 @@ import {
   UPLOAD_RESERVATION_PURPOSES,
 } from '@/lib/storage-quota';
 import { isValidEmailAddress, normalizeEmail } from '@/lib/email-validation';
+import { deriveTimestampFrame } from '@/lib/timecode';
 
 type RouteParams = { params: Promise<{ versionId: string }> };
 const SAFE_AUDIO_PATH =
@@ -429,6 +430,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           content: content?.trim() || null,
           timestamp: parsedTimestamp,
           timestampEnd: parsedTimestampEnd,
+          timestampFrame: deriveTimestampFrame(
+            parsedTimestamp,
+            version.frameRateNum,
+            version.frameRateDen
+          ),
           parentId: parentId || null,
           voiceUrl: voiceUrl || null,
           voiceDuration: voiceDuration || null,

--- a/app/api/versions/[versionId]/transcript/route.ts
+++ b/app/api/versions/[versionId]/transcript/route.ts
@@ -1,0 +1,1 @@
+export { GET, POST } from '@/app/api/v1/versions/[versionId]/transcript/route';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,18 +1,10 @@
-import { after } from 'next/server';
-import { LandingPage } from '@/components/LandingPage';
+import { redirect } from 'next/navigation';
 import { auth } from '@/lib/auth';
-import { readPageVisitor, recordVisitorEvent } from '@/lib/analytics/visitor';
 
 export default async function HomePage() {
   const session = await auth();
-  const isLoggedIn = Boolean(session?.user);
-
-  // Signed-in users land here too, and counting them would put existing
-  // customers at the top of the acquisition funnel.
-  if (!isLoggedIn) {
-    const visitor = await readPageVisitor();
-    after(() => recordVisitorEvent('LANDING_VIEW', visitor));
+  if (session?.user) {
+    redirect('/dashboard');
   }
-
-  return <LandingPage isLoggedIn={isLoggedIn} />;
+  redirect('/login');
 }

--- a/components/video-page-content.tsx
+++ b/components/video-page-content.tsx
@@ -28,6 +28,7 @@ import { CommentsPane } from '@/components/video-page/comments-pane';
 import { AssetsPane } from '@/components/video-page/assets-pane';
 import { ApprovalRequestDialog } from '@/components/video-page/approval-request-dialog';
 import { ApprovalRequestsPanel } from '@/components/video-page/approval-requests-panel';
+import { TranscriptPane } from '@/components/video-page/transcript-pane';
 import type {
   CommentMarker,
   PlayerAdapter,
@@ -108,7 +109,9 @@ export function VideoPageContent({
     toggleVoiceSpeed,
   } = useCommentMedia();
   const [showResolved, setShowResolved] = useState(false);
-  const [activeSidePane, setActiveSidePane] = useState<'comments' | 'assets'>('comments');
+  const [activeSidePane, setActiveSidePane] = useState<'comments' | 'assets' | 'transcript'>(
+    'comments'
+  );
   const [highlightedAssetId, setHighlightedAssetId] = useState<string | null>(null);
 
   const editAnnotationCanvasRef = useRef<AnnotationCanvasHandle>(null);
@@ -483,6 +486,7 @@ export function VideoPageContent({
     commentRangeEnd,
     toggleCommentRangeSelection,
     clearCommentRangeSelection,
+    applyCommentRange,
     isUploadingImage,
     imageInputRef,
     removeImageFile,
@@ -982,6 +986,18 @@ export function VideoPageContent({
               highlightedAssetId={highlightedAssetId}
               onHighlightedAssetHandled={() => setHighlightedAssetId(null)}
               directUploadProvider={directUploadProvider}
+            />
+          }
+          transcriptPane={
+            <TranscriptPane
+              versionId={activeVersionId}
+              currentTime={currentTime}
+              canManage={canManageSubtitles}
+              onSeek={(seconds, options) => handleSeekToTimestamp(seconds, undefined, options)}
+              onCommentRange={(start, end, quote) => {
+                applyCommentRange(start, end, quote);
+                setActiveSidePane('comments');
+              }}
             />
           }
           composer={

--- a/components/video-page/comments-pane.tsx
+++ b/components/video-page/comments-pane.tsx
@@ -3,6 +3,7 @@
 import { memo, useState, type ReactNode, type RefObject } from 'react';
 import {
   ArrowUpRight,
+  Captions,
   CheckCircle2,
   ChevronDown,
   Circle,
@@ -64,7 +65,7 @@ interface CommentsPaneProps {
   isGuest: boolean;
   isExportingCsv: boolean;
   isExportingPdf: boolean;
-  handleExportComments: (format: 'csv' | 'pdf') => void;
+  handleExportComments: (format: 'csv' | 'pdf' | 'edl' | 'fcpxml') => void;
   canResolveComments: boolean;
   handleResolveComment: (commentId: string, currentlyResolved: boolean) => void;
   handleSeekToTimestamp: (
@@ -131,9 +132,10 @@ interface CommentsPaneProps {
   composer: ReactNode;
   assets: VideoAsset[];
   onAssetMentionClick: (assetId: string) => void;
-  activePane: 'comments' | 'assets';
-  setActivePane: (pane: 'comments' | 'assets') => void;
+  activePane: 'comments' | 'assets' | 'transcript';
+  setActivePane: (pane: 'comments' | 'assets' | 'transcript') => void;
   assetsPane: ReactNode;
+  transcriptPane: ReactNode;
 }
 
 export const CommentsPane = memo(function CommentsPane({
@@ -212,6 +214,7 @@ export const CommentsPane = memo(function CommentsPane({
   activePane,
   setActivePane,
   assetsPane,
+  transcriptPane,
 }: CommentsPaneProps) {
   const [isPaneDraggingOver, setIsPaneDraggingOver] = useState(false);
   const formatCommentRange = (timestamp: number, timestampEnd: number | null) => {
@@ -299,6 +302,15 @@ export const CommentsPane = memo(function CommentsPane({
                   {assets.length}
                 </Badge>
               </Button>
+              <Button
+                variant={activePane === 'transcript' ? 'default' : 'ghost'}
+                size="sm"
+                className="h-8 shrink-0"
+                onClick={() => setActivePane('transcript')}
+              >
+                <Captions className="h-4 w-4 mr-1" />
+                Transcript
+              </Button>
             </div>
             <Button
               variant="ghost"
@@ -368,6 +380,36 @@ export const CommentsPane = memo(function CommentsPane({
                     <FileText className="h-4 w-4 mr-2" />
                     Download PDF
                   </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={!activeVersion || isGuest || isExportingCsv || isExportingPdf}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleExportComments('edl');
+                    }}
+                    title={
+                      isGuest
+                        ? 'EDL export requires an authenticated account'
+                        : 'Download comments as an EDL for Premiere, Resolve, and Avid'
+                    }
+                  >
+                    <Download className="h-4 w-4 mr-2" />
+                    Download EDL
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={!activeVersion || isGuest || isExportingCsv || isExportingPdf}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleExportComments('fcpxml');
+                    }}
+                    title={
+                      isGuest
+                        ? 'FCPXML export requires an authenticated account'
+                        : 'Download comments as FCPXML markers'
+                    }
+                  >
+                    <Download className="h-4 w-4 mr-2" />
+                    Download FCPXML
+                  </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
@@ -380,6 +422,13 @@ export const CommentsPane = memo(function CommentsPane({
             aria-hidden={activePane !== 'assets'}
           >
             {assetsPane}
+          </div>
+
+          <div
+            className={cn(activePane === 'transcript' ? 'block p-4 h-full' : 'hidden')}
+            aria-hidden={activePane !== 'transcript'}
+          >
+            {transcriptPane}
           </div>
 
           <div

--- a/components/video-page/hooks/use-comment-actions.ts
+++ b/components/video-page/hooks/use-comment-actions.ts
@@ -165,6 +165,14 @@ export function useCommentActions({
     setCommentRangeEnd(Math.max(commentRangeStart, currentTime));
   }, [commentRangeEnd, commentRangeStart, currentTime]);
 
+  const applyCommentRange = useCallback((start: number, end: number, quote: string) => {
+    setCommentRangeStart(Math.min(start, end));
+    setCommentRangeEnd(Math.max(start, end));
+    if (quote.trim()) {
+      setCommentText((current) => (current.trim() ? current : `"${quote.trim()}"`));
+    }
+  }, []);
+
   const toggleReplyRangeSelection = useCallback(() => {
     if (replyRangeStart === null || replyRangeEnd !== null) {
       setReplyRangeStart(currentTime);
@@ -1309,6 +1317,7 @@ export function useCommentActions({
     commentRangeEnd,
     toggleCommentRangeSelection,
     clearCommentRangeSelection,
+    applyCommentRange,
     isUploadingImage,
     imageInputRef,
     removeImageFile,

--- a/components/video-page/hooks/use-comment-export.ts
+++ b/components/video-page/hooks/use-comment-export.ts
@@ -13,7 +13,7 @@ export function useCommentExport({ activeVersionId, showResolved }: UseCommentEx
   const [isExportingPdf, setIsExportingPdf] = useState(false);
 
   const exportComments = useCallback(
-    async (format: 'csv' | 'pdf') => {
+    async (format: 'csv' | 'pdf' | 'edl' | 'fcpxml') => {
       if (!activeVersionId) return;
 
       if (format === 'csv') {

--- a/components/video-page/transcript-pane.tsx
+++ b/components/video-page/transcript-pane.tsx
@@ -1,0 +1,324 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Captions, Loader2, Search } from 'lucide-react';
+import { List, type RowComponentProps } from 'react-window';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+
+export type TranscriptWord = {
+  start: number;
+  end: number;
+  text: string;
+};
+
+export type TranscriptSegment = {
+  id: string;
+  startSec: number;
+  endSec: number;
+  speaker: string | null;
+  text: string;
+  words: TranscriptWord[] | unknown;
+  position: number;
+};
+
+export type TranscriptPayload = {
+  id: string;
+  versionId: string;
+  language: string;
+  provider: string;
+  status: 'PENDING' | 'RUNNING' | 'READY' | 'FAILED';
+  segments: TranscriptSegment[];
+} | null;
+
+function asWords(value: unknown): TranscriptWord[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (word): word is TranscriptWord =>
+      typeof word === 'object' &&
+      word !== null &&
+      typeof (word as TranscriptWord).text === 'string' &&
+      typeof (word as TranscriptWord).start === 'number' &&
+      typeof (word as TranscriptWord).end === 'number'
+  );
+}
+
+function formatClock(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+function toVttTime(seconds: number): string {
+  const clamped = Math.max(0, seconds);
+  const hours = Math.floor(clamped / 3600);
+  const minutes = Math.floor((clamped % 3600) / 60);
+  const secs = Math.floor(clamped % 60);
+  const millis = Math.round((clamped - Math.floor(clamped)) * 1000);
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+}
+
+interface TranscriptPaneProps {
+  versionId: string | null;
+  currentTime: number;
+  canManage: boolean;
+  onSeek: (
+    seconds: number,
+    options?: { pauseAfterSeek?: boolean; timestampEnd?: number | null }
+  ) => void;
+  onCommentRange: (start: number, end: number, quote: string) => void;
+}
+
+type TranscriptRowProps = {
+  segments: TranscriptSegment[];
+  currentTime: number;
+  onSeek: TranscriptPaneProps['onSeek'];
+  onCommentRange: TranscriptPaneProps['onCommentRange'];
+};
+
+function TranscriptRow({
+  index,
+  style,
+  segments,
+  currentTime,
+  onSeek,
+  onCommentRange,
+}: RowComponentProps<TranscriptRowProps>) {
+  const segment = segments[index];
+  const words = asWords(segment.words);
+  const isActive = currentTime >= segment.startSec && currentTime < segment.endSec;
+
+  const handleMouseUp = () => {
+    const selection = window.getSelection();
+    if (!selection || selection.isCollapsed) return;
+    const quote = selection.toString().trim();
+    if (!quote) return;
+    const matched = words.filter((word) => quote.toLowerCase().includes(word.text.toLowerCase()));
+    const start = matched[0]?.start ?? segment.startSec;
+    const end = matched[matched.length - 1]?.end ?? segment.endSec;
+    onCommentRange(start, end, quote);
+    selection.removeAllRanges();
+  };
+
+  return (
+    <div style={style} className="px-1">
+      <div
+        className={cn(
+          'rounded-md px-2 py-1.5 text-sm h-full',
+          isActive ? 'bg-primary/10' : 'hover:bg-accent/50'
+        )}
+        onMouseUp={handleMouseUp}
+      >
+        <button
+          type="button"
+          className="text-xs text-muted-foreground tabular-nums mb-0.5 hover:text-foreground"
+          onClick={() => onSeek(segment.startSec, { pauseAfterSeek: false })}
+        >
+          {formatClock(segment.startSec)}
+          {segment.speaker ? ` · ${segment.speaker}` : ''}
+        </button>
+        <p className="leading-relaxed line-clamp-2">
+          {words.length > 0 ? (
+            words.map((word, wordIndex) => {
+              const wordActive = currentTime >= word.start && currentTime < word.end;
+              return (
+                <button
+                  key={`${segment.id}-${wordIndex}`}
+                  type="button"
+                  className={cn(
+                    'mr-1 rounded-sm px-0.5',
+                    wordActive ? 'bg-primary text-primary-foreground' : 'hover:bg-accent'
+                  )}
+                  onClick={() => onSeek(word.start, { pauseAfterSeek: false })}
+                >
+                  {word.text}
+                </button>
+              );
+            })
+          ) : (
+            <button
+              type="button"
+              className="text-left"
+              onClick={() => onSeek(segment.startSec, { pauseAfterSeek: false })}
+            >
+              {segment.text}
+            </button>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function TranscriptPane({
+  versionId,
+  currentTime,
+  canManage,
+  onSeek,
+  onCommentRange,
+}: TranscriptPaneProps) {
+  const [transcript, setTranscript] = useState<TranscriptPayload>(null);
+  const [loading, setLoading] = useState(false);
+  const [enqueueing, setEnqueueing] = useState(false);
+  const [query, setQuery] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const fetchTranscript = useCallback(async () => {
+    if (!versionId) {
+      setTranscript(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/versions/${versionId}/transcript`);
+      if (!response.ok) {
+        throw new Error('Failed to load transcript');
+      }
+      const body = (await response.json()) as { data?: { transcript: TranscriptPayload } };
+      setTranscript(body.data?.transcript ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load transcript');
+    } finally {
+      setLoading(false);
+    }
+  }, [versionId]);
+
+  useEffect(() => {
+    void fetchTranscript();
+  }, [fetchTranscript]);
+
+  useEffect(() => {
+    if (!versionId) return;
+    if (transcript?.status !== 'PENDING' && transcript?.status !== 'RUNNING') return;
+    const timer = window.setInterval(() => {
+      void fetchTranscript();
+    }, 4000);
+    return () => window.clearInterval(timer);
+  }, [versionId, transcript?.status, fetchTranscript]);
+
+  const filtered = useMemo(() => {
+    const segments = transcript?.segments ?? [];
+    const needle = query.trim().toLowerCase();
+    if (!needle) return segments;
+    return segments.filter((segment) => segment.text.toLowerCase().includes(needle));
+  }, [transcript, query]);
+
+  const handleDownloadVtt = () => {
+    if (!transcript || transcript.segments.length === 0) return;
+    const body = transcript.segments
+      .map((segment) => {
+        const start = toVttTime(segment.startSec);
+        const end = toVttTime(segment.endSec);
+        return `${start} --> ${end}\n${segment.text}`;
+      })
+      .join('\n\n');
+    const blob = new Blob([`WEBVTT\n\n${body}\n`], { type: 'text/vtt' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'transcript.vtt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleEnqueue = async () => {
+    if (!versionId) return;
+    setEnqueueing(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/versions/${versionId}/transcript`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ language: 'en' }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => null);
+        throw new Error(
+          typeof body?.error === 'string' ? body.error : 'Failed to start transcription'
+        );
+      }
+      await fetchTranscript();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to start transcription');
+    } finally {
+      setEnqueueing(false);
+    }
+  };
+
+  if (!versionId) {
+    return <p className="text-sm text-muted-foreground">Select a version to see its transcript.</p>;
+  }
+
+  const showList = transcript?.status === 'READY' && filtered.length > 0;
+
+  return (
+    <div className="flex flex-col gap-3 h-full min-h-0">
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search transcript"
+            className="pl-8 h-8"
+          />
+        </div>
+        {canManage && (
+          <Button
+            size="sm"
+            className="h-8"
+            onClick={() => void handleEnqueue()}
+            disabled={enqueueing}
+          >
+            {enqueueing ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Captions className="h-4 w-4" />
+            )}
+            <span className="ml-1">{transcript ? 'Re-run' : 'Transcribe'}</span>
+          </Button>
+        )}
+        {transcript?.status === 'READY' && transcript.segments.length > 0 && (
+          <Button size="sm" variant="outline" className="h-8" onClick={handleDownloadVtt}>
+            VTT
+          </Button>
+        )}
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {loading && !transcript ? (
+        <p className="text-sm text-muted-foreground">Loading transcript…</p>
+      ) : transcript?.status === 'PENDING' || transcript?.status === 'RUNNING' ? (
+        <p className="text-sm text-muted-foreground">Transcription in progress…</p>
+      ) : transcript?.status === 'FAILED' ? (
+        <p className="text-sm text-destructive">Transcription failed. Try again.</p>
+      ) : !showList ? (
+        <p className="text-sm text-muted-foreground">
+          {query
+            ? 'No matching lines.'
+            : 'No transcript yet. Generate one to click through the dialogue.'}
+        </p>
+      ) : (
+        <div ref={listRef} className="flex-1 min-h-0">
+          <List
+            rowComponent={TranscriptRow}
+            rowCount={filtered.length}
+            rowHeight={72}
+            rowProps={{
+              segments: filtered,
+              currentTime,
+              onSeek,
+              onCommentRange,
+            }}
+            style={{ height: '100%' }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/video-page/types.ts
+++ b/components/video-page/types.ts
@@ -229,7 +229,7 @@ export interface VideoPageHeaderActions {
 }
 
 export interface VideoPageCommentsActions {
-  onExportComments: (format: 'csv' | 'pdf') => void;
+  onExportComments: (format: 'csv' | 'pdf' | 'edl' | 'fcpxml') => void;
   onResolveComment: (commentId: string, currentlyResolved: boolean) => void;
   onEditComment: (commentId: string) => void;
   onDeleteComment: (commentId: string) => void;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,19 @@ services:
       - '3000:3000'
     restart: unless-stopped
 
+  worker:
+    build:
+      context: ./worker
+      dockerfile: Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    env_file:
+      - .env.docker
+    restart: unless-stopped
+
   postgres:
     image: postgres:16-alpine
     env_file:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -20,7 +20,8 @@ const eslintConfig = defineConfig([
     'playwright-report/**',
     'test-results/**',
     'reports/**',
-    '.stryker-tmp/**',
+    'worker/**',
+    'nle/**',
   ]),
   prettier,
   {

--- a/lib/api-token.ts
+++ b/lib/api-token.ts
@@ -1,0 +1,51 @@
+import { createHash, randomBytes } from 'crypto';
+import { db } from '@/lib/db';
+
+const TOKEN_BYTES = 32;
+const PREFIX = 'of_live_';
+
+export function hashApiToken(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+export function generateApiToken(): { raw: string; hash: string; prefix: string } {
+  const raw = `${PREFIX}${randomBytes(TOKEN_BYTES).toString('hex')}`;
+  return {
+    raw,
+    hash: hashApiToken(raw),
+    prefix: raw.slice(0, PREFIX.length + 8),
+  };
+}
+
+export function extractBearerToken(header: string | null): string | null {
+  if (!header) return null;
+  const match = /^Bearer\s+(\S+)$/i.exec(header.trim());
+  if (!match) return null;
+  const token = match[1];
+  if (!token.startsWith(PREFIX) || token.length < PREFIX.length + 16) return null;
+  return token;
+}
+
+export async function resolveApiToken(
+  raw: string
+): Promise<{ userId: string; tokenId: string } | null> {
+  const hash = hashApiToken(raw);
+  const row = await db.apiToken.findUnique({
+    where: { tokenHash: hash },
+    select: { id: true, userId: true, revokedAt: true, expiresAt: true },
+  });
+
+  if (!row) return null;
+  if (row.revokedAt) return null;
+  if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) return null;
+
+  // Best-effort last-used stamp. A failure here must not fail the request.
+  db.apiToken
+    .update({
+      where: { id: row.id },
+      data: { lastUsedAt: new Date() },
+    })
+    .catch(() => undefined);
+
+  return { userId: row.userId, tokenId: row.id };
+}

--- a/lib/comment-export.ts
+++ b/lib/comment-export.ts
@@ -1,3 +1,6 @@
+import type { FrameRate } from '@/lib/timecode';
+import { framesToTimecode, secondsToFrames } from '@/lib/timecode';
+
 interface ExportAuthor {
   name: string | null;
 }
@@ -335,4 +338,128 @@ function buildSimplePdf(lines: string[]): Buffer {
   pdf += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
 
   return Buffer.from(pdf, 'utf8');
+}
+
+export type MarkerExportMeta = {
+  videoTitle: string;
+  versionNumber: number;
+  versionLabel: string | null;
+  frameRate: FrameRate | null;
+  startTimecode: string | null;
+  durationSeconds: number | null;
+};
+
+const FALLBACK_RATE: FrameRate = { num: 24, den: 1, dropFrame: false };
+
+function rateForExport(meta: MarkerExportMeta): FrameRate {
+  return meta.frameRate ?? FALLBACK_RATE;
+}
+
+function commentTimecode(seconds: number, meta: MarkerExportMeta): string {
+  const rate = rateForExport(meta);
+  return framesToTimecode(secondsToFrames(seconds, rate), rate);
+}
+
+function sanitizeEdlComment(value: string): string {
+  return value.replace(/[\r\n]+/g, ' ').slice(0, 80);
+}
+
+function padEvent(index: number): string {
+  return String(index).padStart(3, '0');
+}
+
+export function buildCommentsEdl(rows: ExportCommentRow[], meta: MarkerExportMeta): string {
+  const rate = rateForExport(meta);
+  const fcm = rate.dropFrame ? 'DROP FRAME' : 'NON-DROP FRAME';
+  const lines = [
+    `TITLE: ${sanitizeEdlComment(meta.videoTitle)} v${meta.versionNumber}`,
+    `FCM: ${fcm}`,
+    '',
+  ];
+
+  const tops = rows.filter((row) => row.level === 0);
+  tops.forEach((row, index) => {
+    const start = commentTimecode(row.timestamp, meta);
+    const endSeconds =
+      row.timestampEnd !== null && row.timestampEnd > row.timestamp
+        ? row.timestampEnd
+        : row.timestamp + 1 / (rate.num / rate.den);
+    const end = commentTimecode(endSeconds, meta);
+    const reel = 'AX';
+    lines.push(
+      `${padEvent(index + 1)}  ${reel.padEnd(8)}V     C        ${start} ${end} ${start} ${end}`
+    );
+    const author = sanitizeEdlComment(row.authorName);
+    const body = sanitizeEdlComment(row.content || '(no text)');
+    lines.push(`* FROM ${author}: ${body}`);
+    if (row.tag) lines.push(`* TAG: ${sanitizeEdlComment(row.tag)}`);
+    lines.push('');
+  });
+
+  return lines.join('\n');
+}
+
+function xmlEscape(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function fcpxmlDuration(seconds: number, rate: FrameRate): string {
+  const frames = Math.max(1, secondsToFrames(seconds, rate));
+  return `${frames * rate.den}/${rate.num}s`;
+}
+
+function fcpxmlTime(seconds: number, rate: FrameRate): string {
+  const frames = secondsToFrames(seconds, rate);
+  if (frames === 0) return '0s';
+  return `${frames * rate.den}/${rate.num}s`;
+}
+
+export function buildCommentsFcpxml(rows: ExportCommentRow[], meta: MarkerExportMeta): string {
+  const rate = rateForExport(meta);
+  const durationSeconds =
+    meta.durationSeconds && meta.durationSeconds > 0 ? meta.durationSeconds : 60;
+  const tops = rows.filter((row) => row.level === 0);
+  const markers = tops
+    .map((row) => {
+      const start = fcpxmlTime(row.timestamp, rate);
+      const duration =
+        row.timestampEnd !== null && row.timestampEnd > row.timestamp
+          ? fcpxmlDuration(row.timestampEnd - row.timestamp, rate)
+          : fcpxmlDuration(1 / (rate.num / rate.den), rate);
+      const value = xmlEscape(
+        `${row.authorName}: ${row.content || '(no text)'}${row.tag ? ` [${row.tag}]` : ''}`
+      );
+      return `              <marker start="${start}" duration="${duration}" value="${value}"/>`;
+    })
+    .join('\n');
+
+  const tcFormat = rate.dropFrame ? 'DF' : 'NDF';
+  const title = xmlEscape(`${meta.videoTitle} v${meta.versionNumber}`);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE fcpxml>
+<fcpxml version="1.9">
+  <resources>
+    <format id="r1" name="FFVideoFormat" frameDuration="${rate.den}/${rate.num}s" width="1920" height="1080"/>
+  </resources>
+  <library>
+    <event name="OpenFrame">
+      <project name="${title}">
+        <sequence format="r1" tcStart="0s" tcFormat="${tcFormat}">
+          <spine>
+            <gap name="Review" offset="0s" duration="${fcpxmlDuration(durationSeconds, rate)}">
+${markers || '              <!-- no comments -->'}
+            </gap>
+          </spine>
+        </sequence>
+      </project>
+    </event>
+  </library>
+</fcpxml>
+`;
 }

--- a/lib/feature-flags.ts
+++ b/lib/feature-flags.ts
@@ -119,6 +119,18 @@ export function isProductAnalyticsEnabled() {
   return readBooleanEnv('OPENFRAME_ENABLE_ANALYTICS', false);
 }
 
+export function isTranscriptionFeatureEnabled() {
+  return readBooleanEnv('OPENFRAME_ENABLE_TRANSCRIPTION', true);
+}
+
+export type TranscriptionProviderName = 'whisper-local' | 'deepgram' | 'openai';
+
+export function getTranscriptionProviderName(): TranscriptionProviderName {
+  const raw = process.env.OPENFRAME_TRANSCRIPTION_PROVIDER?.trim().toLowerCase();
+  if (raw === 'deepgram' || raw === 'openai' || raw === 'whisper-local') return raw;
+  return 'whisper-local';
+}
+
 function parseBigIntEnv(name: string, defaultValue: bigint, minValue?: bigint): bigint {
   const raw = process.env[name]?.trim();
   if (!raw) return defaultValue;

--- a/lib/media-jobs.ts
+++ b/lib/media-jobs.ts
@@ -1,0 +1,41 @@
+import { MediaJobKind, type Prisma } from '@prisma/client';
+import { db } from '@/lib/db';
+import { isTranscriptionFeatureEnabled } from '@/lib/feature-flags';
+
+export async function enqueueMediaJob(
+  versionId: string,
+  kind: MediaJobKind,
+  payload?: Prisma.InputJsonValue
+): Promise<string> {
+  const job = await db.mediaJob.create({
+    data: {
+      versionId,
+      kind,
+      payload: payload ?? undefined,
+    },
+    select: { id: true },
+  });
+  return job.id;
+}
+
+/**
+ * Queue probe (always, for file-backed versions) and transcription (when
+ * enabled). YouTube/Vimeo versions have no file we can ffprobe, so they skip
+ * probe and only transcribe if a later extract step can obtain audio.
+ */
+export async function enqueueJobsForNewVersion(options: {
+  versionId: string;
+  providerId: string;
+}): Promise<void> {
+  const { versionId, providerId } = options;
+  const fileBacked = providerId === 'r2' || providerId === 'bunny';
+
+  if (fileBacked) {
+    await enqueueMediaJob(versionId, MediaJobKind.PROBE_MEDIA);
+  }
+
+  if (isTranscriptionFeatureEnabled() && fileBacked) {
+    await enqueueMediaJob(versionId, MediaJobKind.EXTRACT_AUDIO);
+    await enqueueMediaJob(versionId, MediaJobKind.TRANSCRIBE);
+  }
+}

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -74,6 +74,7 @@ export const RATE_LIMIT_CONFIGS: Record<string, RateLimitConfig> = {
   'subtitle-list': { windowMs: 60 * 1000, maxRequests: 120 }, // 120 per minute
   'subtitle-create': { windowMs: 60 * 1000, maxRequests: 20 }, // 20 per minute
   'subtitle-delete': { windowMs: 60 * 1000, maxRequests: 20 }, // 20 per minute
+  'api-v1': { windowMs: 60 * 1000, maxRequests: 120 }, // 120 per minute
 
   // Search — debounced on client but protect against scripted callers
   search: { windowMs: 60 * 1000, maxRequests: 60 }, // 60 per minute

--- a/lib/timecode.ts
+++ b/lib/timecode.ts
@@ -1,0 +1,196 @@
+/**
+ * Frame-accurate time conversions for review comments and NLE marker sync.
+ *
+ * Frame rates are stored as a reduced rational (num/den), the form ffprobe
+ * returns (`30000/1001`, `25/1`). Never persist a float 29.97 — it drifts.
+ */
+
+export type FrameRate = {
+  num: number;
+  den: number;
+  dropFrame: boolean;
+};
+
+export type ParsedTimecode = {
+  hours: number;
+  minutes: number;
+  seconds: number;
+  frames: number;
+  dropFrame: boolean;
+};
+
+const DROP_FRAME_RATES: ReadonlyArray<readonly [number, number]> = [
+  [30000, 1001],
+  [60000, 1001],
+];
+
+export function gcd(a: number, b: number): number {
+  let x = Math.abs(Math.trunc(a));
+  let y = Math.abs(Math.trunc(b));
+  while (y !== 0) {
+    const next = x % y;
+    x = y;
+    y = next;
+  }
+  return x === 0 ? 1 : x;
+}
+
+export function reduceFrameRate(num: number, den: number): { num: number; den: number } {
+  if (!Number.isInteger(num) || !Number.isInteger(den) || num <= 0 || den <= 0) {
+    throw new Error('Frame rate must be a positive integer ratio');
+  }
+  const divisor = gcd(num, den);
+  return { num: num / divisor, den: den / divisor };
+}
+
+export function parseFrameRateString(value: string): { num: number; den: number } | null {
+  const match = /^(\d+)\s*\/\s*(\d+)$/.exec(value.trim());
+  if (!match) return null;
+  const num = Number(match[1]);
+  const den = Number(match[2]);
+  if (!Number.isInteger(num) || !Number.isInteger(den) || num <= 0 || den <= 0) return null;
+  return reduceFrameRate(num, den);
+}
+
+export function isNtscDropFrameRate(num: number, den: number): boolean {
+  const reduced = reduceFrameRate(num, den);
+  return DROP_FRAME_RATES.some(([n, d]) => n === reduced.num && d === reduced.den);
+}
+
+export function nominalFps(rate: FrameRate): number {
+  if (rate.num === 30000 && rate.den === 1001) return 30;
+  if (rate.num === 60000 && rate.den === 1001) return 60;
+  return Math.round(rate.num / rate.den);
+}
+
+/**
+ * Convert a media time in seconds to a frame index. The epsilon keeps a time
+ * that lands exactly on a boundary from floating-point-ing down a frame.
+ */
+export function secondsToFrames(seconds: number, rate: FrameRate): number {
+  if (!Number.isFinite(seconds) || seconds < 0) return 0;
+  return Math.floor((seconds * rate.num) / rate.den + 1e-6);
+}
+
+export function framesToSeconds(frames: number, rate: FrameRate): number {
+  if (!Number.isFinite(frames) || frames < 0) return 0;
+  return (frames * rate.den) / rate.num;
+}
+
+export function deriveTimestampFrame(
+  seconds: number,
+  num: number | null | undefined,
+  den: number | null | undefined
+): number | null {
+  if (typeof num !== 'number' || typeof den !== 'number') return null;
+  if (!Number.isInteger(num) || !Number.isInteger(den) || num <= 0 || den <= 0) return null;
+  return secondsToFrames(seconds, { num, den, dropFrame: false });
+}
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+/**
+ * Non-drop-frame SMPTE from a frame count. The separator is `:` throughout.
+ */
+export function framesToTimecodeNdf(frameNumber: number, fps: number): string {
+  const fpsInt = Math.max(1, Math.round(fps));
+  const clamped = Math.max(0, Math.floor(frameNumber));
+  const frames = clamped % fpsInt;
+  const totalSeconds = Math.floor(clamped / fpsInt);
+  const seconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const hours = Math.floor(totalMinutes / 60);
+  return `${pad2(hours)}:${pad2(minutes)}:${pad2(seconds)}:${pad2(frames)}`;
+}
+
+/**
+ * Drop-frame SMPTE. 29.97 drops 2 frames every minute except every 10th;
+ * 59.94 drops 4. The separator before frames is `;`.
+ */
+export function framesToTimecodeDf(frameNumber: number, nominal: 30 | 60): string {
+  const dropFrames = nominal === 30 ? 2 : 4;
+  const framesPerMinute = nominal * 60;
+  const framesPer10Minutes = framesPerMinute * 10 - 9 * dropFrames;
+  const clamped = Math.max(0, Math.floor(frameNumber));
+
+  const d = Math.floor(clamped / framesPer10Minutes);
+  const m = clamped % framesPer10Minutes;
+
+  let f = clamped + 9 * dropFrames * d;
+  if (m > dropFrames) {
+    f += dropFrames * Math.floor((m - dropFrames) / (framesPerMinute - dropFrames));
+  }
+
+  const frames = f % nominal;
+  const totalSeconds = Math.floor(f / nominal);
+  const seconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const hours = Math.floor(totalMinutes / 60);
+  return `${pad2(hours)}:${pad2(minutes)}:${pad2(seconds)};${pad2(frames)}`;
+}
+
+export function framesToTimecode(frameNumber: number, rate: FrameRate): string {
+  if (rate.dropFrame && isNtscDropFrameRate(rate.num, rate.den)) {
+    const nominal = rate.num === 60000 ? 60 : 30;
+    return framesToTimecodeDf(frameNumber, nominal);
+  }
+  return framesToTimecodeNdf(frameNumber, nominalFps(rate));
+}
+
+export function parseTimecode(value: string): ParsedTimecode | null {
+  const match = /^(\d{1,3}):([0-5]\d):([0-5]\d)([:;])(\d{1,3})$/.exec(value.trim());
+  if (!match) return null;
+  return {
+    hours: Number(match[1]),
+    minutes: Number(match[2]),
+    seconds: Number(match[3]),
+    frames: Number(match[5]),
+    dropFrame: match[4] === ';',
+  };
+}
+
+export function timecodeToFrames(value: string, rate: FrameRate): number | null {
+  const parsed = parseTimecode(value);
+  if (!parsed) return null;
+
+  const fps = parsed.dropFrame ? (rate.num === 60000 ? 60 : 30) : nominalFps(rate);
+
+  if (parsed.frames >= fps) return null;
+
+  if (parsed.dropFrame) {
+    const dropFrames = fps === 60 ? 4 : 2;
+    const totalMinutes = parsed.hours * 60 + parsed.minutes;
+    const dropped = dropFrames * (totalMinutes - Math.floor(totalMinutes / 10));
+    return (
+      (parsed.hours * 3600 + parsed.minutes * 60 + parsed.seconds) * fps + parsed.frames - dropped
+    );
+  }
+
+  return (parsed.hours * 3600 + parsed.minutes * 60 + parsed.seconds) * fps + parsed.frames;
+}
+
+export function secondsToTimecode(seconds: number, rate: FrameRate): string {
+  return framesToTimecode(secondsToFrames(seconds, rate), rate);
+}
+
+export type SequenceOffset = {
+  startTimecode: string;
+  rate: FrameRate;
+};
+
+/**
+ * Convert a comment time (seconds from the start of the review file, which is
+ * 00:00:00:00) into a sequence frame index by adding the sequence start.
+ */
+export function commentSecondsToSequenceFrames(
+  seconds: number,
+  offset: SequenceOffset
+): number | null {
+  const startFrames = timecodeToFrames(offset.startTimecode, offset.rate);
+  if (startFrames === null) return null;
+  return startFrames + secondsToFrames(seconds, offset.rate);
+}

--- a/lib/transcription/deepgram.ts
+++ b/lib/transcription/deepgram.ts
@@ -1,0 +1,89 @@
+import type { TranscriptionProvider, TranscriptionResult } from '@/lib/transcription/types';
+
+export const deepgramProvider: TranscriptionProvider = {
+  name: 'deepgram',
+  async transcribe(input: { audioPath: string; language?: string }): Promise<TranscriptionResult> {
+    const apiKey = process.env.DEEPGRAM_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error('DEEPGRAM_API_KEY is not set');
+    }
+
+    const fs = await import('node:fs/promises');
+    const audio = await fs.readFile(input.audioPath);
+    const params = new URLSearchParams({
+      model: 'nova-2',
+      smart_format: 'true',
+      utterances: 'true',
+      punctuate: 'true',
+    });
+    if (input.language) params.set('language', input.language);
+
+    const response = await fetch(`https://api.deepgram.com/v1/listen?${params.toString()}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Token ${apiKey}`,
+        'Content-Type': 'audio/wav',
+      },
+      body: audio,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Deepgram returned ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      results?: {
+        channels?: Array<{
+          alternatives?: Array<{
+            transcript?: string;
+            words?: Array<{ word?: string; start?: number; end?: number }>;
+          }>;
+        }>;
+      };
+    };
+
+    const words = body.results?.channels?.[0]?.alternatives?.[0]?.words ?? [];
+    const mapped = words
+      .filter((word) => typeof word.word === 'string')
+      .map((word) => ({
+        start: typeof word.start === 'number' ? word.start : 0,
+        end: typeof word.end === 'number' ? word.end : 0,
+        text: word.word as string,
+      }));
+
+    return {
+      language: input.language ?? 'en',
+      segments: groupWordsIntoCues(mapped),
+    };
+  },
+};
+
+function groupWordsIntoCues(
+  words: Array<{ start: number; end: number; text: string }>
+): TranscriptionResult['segments'] {
+  if (words.length === 0) return [];
+
+  const cues: TranscriptionResult['segments'] = [];
+  let current: TranscriptionResult['segments'][number] = {
+    start: words[0].start,
+    end: words[0].end,
+    text: words[0].text,
+    words: [words[0]],
+  };
+
+  for (let index = 1; index < words.length; index += 1) {
+    const word = words[index];
+    const gap = word.start - current.end;
+    const wouldBeLong = current.text.length + word.text.length + 1 > 80;
+    if (gap > 0.8 || wouldBeLong) {
+      cues.push(current);
+      current = { start: word.start, end: word.end, text: word.text, words: [word] };
+    } else {
+      current.end = word.end;
+      current.text = `${current.text} ${word.text}`;
+      current.words.push(word);
+    }
+  }
+  cues.push(current);
+  return cues;
+}

--- a/lib/transcription/index.ts
+++ b/lib/transcription/index.ts
@@ -1,0 +1,23 @@
+import { getTranscriptionProviderName } from '@/lib/feature-flags';
+import { deepgramProvider } from '@/lib/transcription/deepgram';
+import { openaiProvider } from '@/lib/transcription/openai';
+import { whisperLocalProvider } from '@/lib/transcription/whisper-local';
+import type { TranscriptionProvider } from '@/lib/transcription/types';
+
+export function getTranscriptionProvider(): TranscriptionProvider {
+  switch (getTranscriptionProviderName()) {
+    case 'deepgram':
+      return deepgramProvider;
+    case 'openai':
+      return openaiProvider;
+    default:
+      return whisperLocalProvider;
+  }
+}
+
+export type {
+  TranscriptionProvider,
+  TranscriptionResult,
+  TranscriptCue,
+  TranscriptWord,
+} from '@/lib/transcription/types';

--- a/lib/transcription/openai.ts
+++ b/lib/transcription/openai.ts
@@ -1,0 +1,93 @@
+import type { TranscriptionProvider, TranscriptionResult } from '@/lib/transcription/types';
+
+export const openaiProvider: TranscriptionProvider = {
+  name: 'openai',
+  async transcribe(input: { audioPath: string; language?: string }): Promise<TranscriptionResult> {
+    const apiKey = process.env.OPENAI_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error('OPENAI_API_KEY is not set');
+    }
+
+    const fs = await import('node:fs/promises');
+    const path = await import('node:path');
+    const audio = await fs.readFile(input.audioPath);
+    const fileName = path.basename(input.audioPath) || 'audio.wav';
+
+    const form = new FormData();
+    form.set('model', 'whisper-1');
+    form.set('response_format', 'verbose_json');
+    form.set('timestamp_granularities[]', 'word');
+    if (input.language) form.set('language', input.language);
+    form.set('file', new Blob([audio], { type: 'audio/wav' }), fileName);
+
+    const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: form,
+    });
+
+    if (!response.ok) {
+      throw new Error(`OpenAI transcription returned ${response.status}`);
+    }
+
+    const body = (await response.json()) as {
+      language?: string;
+      words?: Array<{ word?: string; start?: number; end?: number }>;
+      segments?: Array<{ start?: number; end?: number; text?: string }>;
+    };
+
+    const words = (body.words ?? [])
+      .filter((word) => typeof word.word === 'string')
+      .map((word) => ({
+        start: typeof word.start === 'number' ? word.start : 0,
+        end: typeof word.end === 'number' ? word.end : 0,
+        text: word.word as string,
+      }));
+
+    if (words.length > 0) {
+      return {
+        language: body.language ?? input.language ?? 'en',
+        segments: groupWords(words),
+      };
+    }
+
+    return {
+      language: body.language ?? input.language ?? 'en',
+      segments: (body.segments ?? [])
+        .filter((segment) => typeof segment.text === 'string' && segment.text.trim())
+        .map((segment) => ({
+          start: typeof segment.start === 'number' ? segment.start : 0,
+          end: typeof segment.end === 'number' ? segment.end : 0,
+          text: (segment.text as string).trim(),
+          words: [],
+        })),
+    };
+  },
+};
+
+function groupWords(
+  words: Array<{ start: number; end: number; text: string }>
+): TranscriptionResult['segments'] {
+  if (words.length === 0) return [];
+  const cues: TranscriptionResult['segments'] = [];
+  let current: TranscriptionResult['segments'][number] = {
+    start: words[0].start,
+    end: words[0].end,
+    text: words[0].text,
+    words: [words[0]],
+  };
+
+  for (let index = 1; index < words.length; index += 1) {
+    const word = words[index];
+    if (word.start - current.end > 0.8 || current.text.length > 80) {
+      cues.push(current);
+      current = { start: word.start, end: word.end, text: word.text, words: [word] };
+    } else {
+      current.end = word.end;
+      current.text = `${current.text} ${word.text}`;
+      current.words.push(word);
+    }
+  }
+  cues.push(current);
+  return cues;
+}

--- a/lib/transcription/types.ts
+++ b/lib/transcription/types.ts
@@ -1,0 +1,23 @@
+export type TranscriptWord = {
+  start: number;
+  end: number;
+  text: string;
+};
+
+export type TranscriptCue = {
+  start: number;
+  end: number;
+  speaker?: string;
+  text: string;
+  words: TranscriptWord[];
+};
+
+export type TranscriptionResult = {
+  language: string;
+  segments: TranscriptCue[];
+};
+
+export interface TranscriptionProvider {
+  name: string;
+  transcribe(input: { audioPath: string; language?: string }): Promise<TranscriptionResult>;
+}

--- a/lib/transcription/whisper-local.ts
+++ b/lib/transcription/whisper-local.ts
@@ -1,0 +1,15 @@
+import type { TranscriptionProvider, TranscriptionResult } from '@/lib/transcription/types';
+
+/**
+ * Default provider. The actual faster-whisper call runs in the media worker;
+ * this module is the in-process contract the API uses to name the provider.
+ * The worker imports the same types and writes segments back through Prisma.
+ */
+export const whisperLocalProvider: TranscriptionProvider = {
+  name: 'whisper-local',
+  async transcribe(): Promise<TranscriptionResult> {
+    throw new Error(
+      'whisper-local runs in the media worker, not in the Next.js process. Enqueue a TRANSCRIBE job.'
+    );
+  },
+};

--- a/lib/v1-auth.ts
+++ b/lib/v1-auth.ts
@@ -1,0 +1,95 @@
+import { NextRequest } from 'next/server';
+import { auth, checkProjectAccess, checkWorkspaceAccess } from '@/lib/auth';
+import { extractBearerToken, resolveApiToken } from '@/lib/api-token';
+import { apiErrors } from '@/lib/api-response';
+import { db } from '@/lib/db';
+
+export type ApiAuthContext = {
+  userId: string;
+  tokenId: string | null;
+};
+
+/**
+ * Resolves the caller to a user id. A Bearer API token wins; a NextAuth
+ * session is accepted so the same v1 routes can be used from the browser
+ * during development without minting a token.
+ */
+export async function withApiAuth(
+  request: NextRequest
+): Promise<ApiAuthContext | ReturnType<typeof apiErrors.unauthorized>> {
+  const bearer = extractBearerToken(request.headers.get('authorization'));
+  if (bearer) {
+    const resolved = await resolveApiToken(bearer);
+    if (!resolved) return apiErrors.unauthorized('Invalid API token');
+    return resolved;
+  }
+
+  const session = await auth();
+  if (!session?.user?.id) {
+    return apiErrors.unauthorized();
+  }
+  return { userId: session.user.id, tokenId: null };
+}
+
+export function isAuthError(
+  value: ApiAuthContext | ReturnType<typeof apiErrors.unauthorized>
+): value is ReturnType<typeof apiErrors.unauthorized> {
+  return !('userId' in value);
+}
+
+export async function loadVersionForUser(versionId: string, userId: string) {
+  const version = await db.videoVersion.findUnique({
+    where: { id: versionId },
+    include: {
+      video: {
+        include: {
+          project: {
+            select: {
+              id: true,
+              ownerId: true,
+              workspaceId: true,
+              visibility: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!version)
+    return { error: apiErrors.notFound('Version') as ReturnType<typeof apiErrors.notFound> };
+
+  const access = await checkProjectAccess(version.video.project, userId);
+  if (!access.hasAccess) {
+    return { error: apiErrors.notFound('Version') as ReturnType<typeof apiErrors.notFound> };
+  }
+
+  return { version, access };
+}
+
+export async function loadProjectForUser(projectId: string, userId: string) {
+  const project = await db.project.findUnique({
+    where: { id: projectId },
+    select: {
+      id: true,
+      ownerId: true,
+      workspaceId: true,
+      visibility: true,
+      name: true,
+      slug: true,
+    },
+  });
+
+  if (!project)
+    return { error: apiErrors.notFound('Project') as ReturnType<typeof apiErrors.notFound> };
+
+  const access = await checkProjectAccess(project, userId);
+  if (!access.hasAccess) {
+    return { error: apiErrors.notFound('Project') as ReturnType<typeof apiErrors.notFound> };
+  }
+
+  return { project, access };
+}
+
+export { checkProjectAccess, checkWorkspaceAccess };

--- a/nle/NLE_DECISION.md
+++ b/nle/NLE_DECISION.md
@@ -1,0 +1,18 @@
+# NLE panel decision
+
+Shipped first: EDL and FCPXML export from the review page. That puts comments on
+the timeline in Premiere, Resolve (including the free edition), Avid, and FCP
+with no plugin.
+
+Because the edition mix is still unknown, this fork includes **both** panels as
+specified in the plan:
+
+- Premiere Pro 25.6+ UXP panel in `nle/premiere` (side-load with UXP Developer Tool)
+- DaVinci Resolve Studio Workflow Integration plugin in `nle/resolve`
+
+Free Resolve keeps using the EDL import path. If the team later confirms a
+single NLE, the unused panel can be ignored; both are isolated under `nle/`.
+
+Live two-way sync is a convenience on top of the file-based workflow, not a
+replacement for it. Try the EDL first. Adopt the panel if editors want markers
+to update without re-importing.

--- a/nle/core/package.json
+++ b/nle/core/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@openframe/nle-core",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  }
+}

--- a/nle/core/src/index.ts
+++ b/nle/core/src/index.ts
@@ -1,0 +1,194 @@
+export type FrameRate = {
+  num: number;
+  den: number;
+  dropFrame: boolean;
+};
+
+export type RemoteComment = {
+  id: string;
+  content: string | null;
+  timestamp: number;
+  timestampEnd: number | null;
+  timestampFrame: number | null;
+  isResolved: boolean;
+  parentId: string | null;
+  author: { name: string | null } | null;
+  guestName: string | null;
+  tag: { name: string; color: string } | null;
+  updatedAt: string;
+};
+
+export type LocalMarker = {
+  id: string;
+  commentId: string | null;
+  startSeconds: number;
+  durationSeconds: number;
+  name: string;
+  comments: string;
+  color?: string;
+};
+
+export type SyncPlan = {
+  add: RemoteComment[];
+  move: Array<{ comment: RemoteComment; marker: LocalMarker }>;
+  remove: LocalMarker[];
+};
+
+export const SENTINEL_RE = /\[of:([a-z0-9]+)\]/i;
+
+export function commentSentinel(commentId: string): string {
+  return `[of:${commentId}]`;
+}
+
+export function parseSentinel(text: string): string | null {
+  const match = SENTINEL_RE.exec(text);
+  return match ? match[1] : null;
+}
+
+export function commentLabel(comment: RemoteComment): string {
+  const author = comment.author?.name || comment.guestName || 'Note';
+  const body = (comment.content || '').replace(/\s+/g, ' ').trim().slice(0, 60);
+  return body ? `${author}: ${body}` : author;
+}
+
+export function markerCommentBody(comment: RemoteComment): string {
+  const lines = [comment.content || '', commentSentinel(comment.id)];
+  return lines.filter(Boolean).join('\n');
+}
+
+export function reconcile(remote: RemoteComment[], local: LocalMarker[]): SyncPlan {
+  const tops = remote.filter((comment) => comment.parentId === null && !comment.isResolved);
+  const byId = new Map(tops.map((comment) => [comment.id, comment]));
+  const localByComment = new Map<string, LocalMarker>();
+  const orphans: LocalMarker[] = [];
+
+  for (const marker of local) {
+    const commentId = marker.commentId ?? parseSentinel(marker.comments);
+    if (!commentId) continue;
+    if (!byId.has(commentId)) {
+      orphans.push(marker);
+      continue;
+    }
+    localByComment.set(commentId, marker);
+  }
+
+  const add: RemoteComment[] = [];
+  const move: SyncPlan['move'] = [];
+
+  for (const comment of tops) {
+    const existing = localByComment.get(comment.id);
+    if (!existing) {
+      add.push(comment);
+      continue;
+    }
+    const drift = Math.abs(existing.startSeconds - comment.timestamp);
+    if (drift > 0.02) {
+      move.push({ comment, marker: existing });
+    }
+  }
+
+  return { add, move, remove: orphans };
+}
+
+export function nearestResolveColor(hex: string | null | undefined): string {
+  const palette: Array<{ name: string; r: number; g: number; b: number }> = [
+    { name: 'Blue', r: 59, g: 130, b: 246 },
+    { name: 'Red', r: 239, g: 68, b: 68 },
+    { name: 'Green', r: 34, g: 197, b: 94 },
+    { name: 'Yellow', r: 234, g: 179, b: 8 },
+    { name: 'Cyan', r: 6, g: 182, b: 212 },
+    { name: 'Pink', r: 236, g: 72, b: 153 },
+    { name: 'Purple', r: 168, g: 85, b: 247 },
+    { name: 'Orange', r: 249, g: 115, b: 22 },
+  ];
+  if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return 'Blue';
+  const value = hex.replace('#', '');
+  const r = Number.parseInt(value.slice(0, 2), 16);
+  const g = Number.parseInt(value.slice(2, 4), 16);
+  const b = Number.parseInt(value.slice(4, 6), 16);
+  let best = palette[0];
+  let bestDist = Infinity;
+  for (const color of palette) {
+    const dist = (color.r - r) ** 2 + (color.g - g) ** 2 + (color.b - b) ** 2;
+    if (dist < bestDist) {
+      best = color;
+      bestDist = dist;
+    }
+  }
+  return best.name;
+}
+
+export class OpenFrameClient {
+  constructor(
+    private readonly baseUrl: string,
+    private readonly token: string
+  ) {}
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const response = await fetch(`${this.baseUrl.replace(/\/$/, '')}${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+        ...(init.headers ?? {}),
+      },
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      const message = body && typeof body.error === 'string' ? body.error : `HTTP ${response.status}`;
+      throw new Error(message);
+    }
+    const json = (await response.json()) as { data: T };
+    return json.data;
+  }
+
+  listProjects() {
+    return this.request<{ projects: Array<{ id: string; name: string }> }>('/api/v1/projects');
+  }
+
+  listVideos(projectId: string) {
+    return this.request<{
+      videos: Array<{
+        id: string;
+        title: string;
+        versions: Array<{
+          id: string;
+          versionNumber: number;
+          isActive: boolean;
+          frameRateNum: number | null;
+          frameRateDen: number | null;
+          dropFrame: boolean;
+          startTimecode: string | null;
+        }>;
+      }>;
+    }>(`/api/v1/projects/${projectId}/videos`);
+  }
+
+  getVersion(versionId: string) {
+    return this.request<{
+      version: {
+        id: string;
+        frameRateNum: number | null;
+        frameRateDen: number | null;
+        dropFrame: boolean;
+        startTimecode: string | null;
+        duration: number | null;
+        video: { title: string };
+      };
+    }>(`/api/v1/versions/${versionId}`);
+  }
+
+  listComments(versionId: string, updatedSince?: string) {
+    const query = updatedSince ? `?updatedSince=${encodeURIComponent(updatedSince)}` : '';
+    return this.request<{ comments: RemoteComment[] }>(
+      `/api/v1/versions/${versionId}/comments${query}`
+    );
+  }
+
+  resolveComment(commentId: string, isResolved: boolean) {
+    return this.request(`/api/v1/comments/${commentId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ isResolved }),
+    });
+  }
+}

--- a/nle/premiere/README.md
+++ b/nle/premiere/README.md
@@ -1,0 +1,14 @@
+# Premiere Pro review panel
+
+Requires Premiere Pro 25.6+ (the `Markers` API). Distribute internally by
+side-loading this folder with the UXP Developer Tool — no Adobe Exchange review.
+
+1. In the review app, open Settings and create an API token.
+2. Load this folder in UXP Developer Tool and run it against Premiere Pro.
+3. Paste the app URL and token, load projects, pick a version, Sync markers.
+
+Each marker’s comment ends with `[of:<commentId>]` so a later sync can add,
+move, or remove markers as a single undoable transaction.
+
+Sequence start timecode (often `01:00:00:00`) is read once per sync and added to
+comment times. Review files are treated as starting at `00:00:00:00`.

--- a/nle/premiere/index.html
+++ b/nle/premiere/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Review markers</title>
+    <style>
+      :root { color-scheme: dark; font-family: system-ui, sans-serif; }
+      body { margin: 12px; background: #1b1b1b; color: #eee; }
+      label, input, button, select { font: inherit; }
+      input, select { width: 100%; box-sizing: border-box; margin: 4px 0 10px; padding: 6px; }
+      button { padding: 8px 12px; cursor: pointer; }
+      .row { display: flex; gap: 8px; }
+      .status { margin-top: 12px; white-space: pre-wrap; font-size: 12px; color: #bbb; }
+      .hint { font-size: 12px; color: #888; }
+    </style>
+  </head>
+  <body>
+    <p class="hint">Create an API token in Settings, then paste it here. Side-load this folder with the UXP Developer Tool.</p>
+    <label>App URL</label>
+    <input id="baseUrl" value="http://localhost:3000" />
+    <label>API token</label>
+    <input id="token" type="password" placeholder="of_live_…" />
+    <label>Project</label>
+    <select id="project"><option value="">Load projects…</option></select>
+    <label>Version</label>
+    <select id="version"><option value="">Select a project first</option></select>
+    <div class="row">
+      <button id="load">Load projects</button>
+      <button id="sync">Sync markers</button>
+    </div>
+    <div class="status" id="status"></div>
+    <script src="panel.js"></script>
+  </body>
+</html>

--- a/nle/premiere/manifest.json
+++ b/nle/premiere/manifest.json
@@ -1,0 +1,28 @@
+{
+  "id": "com.internal.openframe.premiere",
+  "name": "Internal Review (Premiere)",
+  "version": "0.1.0",
+  "manifestVersion": 5,
+  "host": [
+    {
+      "app": "premierepro",
+      "minVersion": "25.6.0"
+    }
+  ],
+  "main": "index.html",
+  "entrypoints": [
+    {
+      "type": "panel",
+      "id": "openframe.panel",
+      "label": {
+        "default": "Review markers"
+      }
+    }
+  ],
+  "requiredPermissions": {
+    "network": {
+      "domains": "all"
+    },
+    "localFileSystem": "plugin"
+  }
+}

--- a/nle/premiere/package.json
+++ b/nle/premiere/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@openframe/premiere-panel",
+  "private": true,
+  "type": "module"
+}

--- a/nle/premiere/panel.js
+++ b/nle/premiere/panel.js
@@ -1,0 +1,163 @@
+/* global require */
+const SENTINEL_RE = /\[of:([a-z0-9]+)\]/i;
+
+function commentSentinel(id) {
+  return `[of:${id}]`;
+}
+
+function parseSentinel(text) {
+  const match = SENTINEL_RE.exec(text || '');
+  return match ? match[1] : null;
+}
+
+function setStatus(message) {
+  document.getElementById('status').textContent = message;
+}
+
+async function api(baseUrl, token, path) {
+  const response = await fetch(`${baseUrl.replace(/\/$/, '')}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    throw new Error(body?.error || `HTTP ${response.status}`);
+  }
+  const json = await response.json();
+  return json.data;
+}
+
+function secondsFromTick(tick) {
+  if (!tick) return 0;
+  if (typeof tick.seconds === 'number') return tick.seconds;
+  if (typeof tick.sec === 'number') return tick.sec;
+  if (typeof tick.ticks === 'number' && typeof tick.ticksPerSecond === 'number' && tick.ticksPerSecond) {
+    return tick.ticks / tick.ticksPerSecond;
+  }
+  return 0;
+}
+
+async function sequenceStartOffsetSeconds(ppro, sequence) {
+  try {
+    const settings = await sequence.getSettings?.();
+    const start = settings?.startTime ?? settings?.zeroPoint ?? null;
+    return secondsFromTick(start);
+  } catch {
+    return 0;
+  }
+}
+
+async function syncMarkers() {
+  const baseUrl = document.getElementById('baseUrl').value.trim();
+  const token = document.getElementById('token').value.trim();
+  const versionId = document.getElementById('version').value;
+  if (!token || !versionId) {
+    setStatus('Token and version are required.');
+    return;
+  }
+
+  const ppro = require('premierepro');
+  const project = await ppro.Project.getActiveProject();
+  if (!project) throw new Error('No active Premiere project');
+  const sequence = await project.getActiveSequence();
+  if (!sequence) throw new Error('No active sequence');
+  const sequenceMarkers = await ppro.Markers.getMarkers(sequence);
+  const existing = await sequenceMarkers.getMarkers();
+  const offsetSeconds = await sequenceStartOffsetSeconds(ppro, sequence);
+
+  const { comments } = await api(baseUrl, token, `/api/v1/versions/${versionId}/comments`);
+  const remote = comments.filter((comment) => !comment.parentId && !comment.isResolved);
+
+  const localByComment = new Map();
+  for (const marker of existing) {
+    const commentsText = marker.comments || marker.getComments?.() || '';
+    const commentId = parseSentinel(commentsText);
+    if (commentId) localByComment.set(commentId, marker);
+  }
+
+  let added = 0;
+  let moved = 0;
+  let removed = 0;
+
+  project.lockedAccess(() => {
+    project.executeTransaction((compound) => {
+      for (const comment of remote) {
+        const start = ppro.TickTime.createWithSeconds(comment.timestamp + offsetSeconds);
+        const durationSeconds =
+          comment.timestampEnd && comment.timestampEnd > comment.timestamp
+            ? comment.timestampEnd - comment.timestamp
+            : 0;
+        const duration =
+          durationSeconds > 0
+            ? ppro.TickTime.createWithSeconds(durationSeconds)
+            : ppro.TickTime.TIME_ZERO;
+        const name = (comment.content || 'Note').slice(0, 40);
+        const body = `${comment.content || ''}\n${commentSentinel(comment.id)}`.trim();
+        const existingMarker = localByComment.get(comment.id);
+        if (!existingMarker) {
+          compound.addAction(
+            sequenceMarkers.createAddMarkerAction(
+              name,
+              ppro.Marker.MARKER_TYPE_COMMENT,
+              start,
+              duration,
+              body
+            )
+          );
+          added += 1;
+        } else {
+          const current = secondsFromTick(existingMarker.start);
+          if (Math.abs(current - (comment.timestamp + offsetSeconds)) > 0.02) {
+            compound.addAction(sequenceMarkers.createMoveMarkerAction(existingMarker, start));
+            moved += 1;
+          }
+        }
+      }
+
+      for (const [commentId, marker] of localByComment) {
+        if (!remote.some((comment) => comment.id === commentId)) {
+          compound.addAction(sequenceMarkers.createRemoveMarkerAction(marker));
+          removed += 1;
+        }
+      }
+    }, 'Sync review comments');
+  });
+
+  setStatus(`Synced. Added ${added}, moved ${moved}, removed ${removed}. Offset ${offsetSeconds.toFixed(2)}s.`);
+}
+
+async function loadProjects() {
+  const baseUrl = document.getElementById('baseUrl').value.trim();
+  const token = document.getElementById('token').value.trim();
+  const { projects } = await api(baseUrl, token, '/api/v1/projects');
+  const select = document.getElementById('project');
+  select.innerHTML = projects
+    .map((project) => `<option value="${project.id}">${project.name}</option>`)
+    .join('');
+  if (projects[0]) await loadVersions(projects[0].id);
+}
+
+async function loadVersions(projectId) {
+  const baseUrl = document.getElementById('baseUrl').value.trim();
+  const token = document.getElementById('token').value.trim();
+  const { videos } = await api(baseUrl, token, `/api/v1/projects/${projectId}/videos`);
+  const select = document.getElementById('version');
+  const options = [];
+  for (const video of videos) {
+    for (const version of video.versions) {
+      options.push(
+        `<option value="${version.id}">${video.title} v${version.versionNumber}</option>`
+      );
+    }
+  }
+  select.innerHTML = options.join('') || '<option value="">No versions</option>';
+}
+
+document.getElementById('load').addEventListener('click', () => {
+  loadProjects().catch((error) => setStatus(error.message));
+});
+document.getElementById('project').addEventListener('change', (event) => {
+  loadVersions(event.target.value).catch((error) => setStatus(error.message));
+});
+document.getElementById('sync').addEventListener('click', () => {
+  syncMarkers().catch((error) => setStatus(error.message));
+});

--- a/nle/resolve/README.md
+++ b/nle/resolve/README.md
@@ -1,0 +1,15 @@
+This is a DaVinci Resolve Studio Workflow Integration plugin.
+
+Free Resolve cannot script from outside the app (locked since 19.1). Free-edition
+editors should import the EDL from the review page (Download EDL).
+
+Studio install (macOS example):
+
+1. Copy this folder to:
+   `~/Library/Application Support/Blackmagic Design/DaVinci Resolve/Workflow Integration Plugins/OpenFrame`
+2. Restart Resolve.
+3. Workspace → Workflow Integrations → Review markers.
+4. Paste an API token from Settings.
+
+The plugin writes timeline markers with `customData` JSON `{"ofId":"<commentId>"}`
+so a second sync is idempotent.

--- a/nle/resolve/index.html
+++ b/nle/resolve/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Review markers</title>
+    <style>
+      :root { color-scheme: dark; font-family: system-ui, sans-serif; }
+      body { margin: 12px; background: #1b1b1b; color: #eee; }
+      input { width: 100%; box-sizing: border-box; margin: 4px 0 10px; padding: 6px; }
+      button { padding: 8px 12px; }
+      .status { margin-top: 12px; font-size: 12px; color: #bbb; white-space: pre-wrap; }
+    </style>
+  </head>
+  <body>
+    <p>Studio only. Free Resolve: import the EDL from the review page.</p>
+    <label>App URL</label>
+    <input id="baseUrl" value="http://localhost:3000" />
+    <label>API token</label>
+    <input id="token" type="password" />
+    <label>Version id</label>
+    <input id="versionId" placeholder="clxxxxxxxx" />
+    <button id="sync">Sync markers</button>
+    <div class="status" id="status"></div>
+    <script>
+      const { ipcRenderer } = require('electron');
+      document.getElementById('sync').addEventListener('click', async () => {
+        try {
+          const message = await ipcRenderer.invoke('sync', {
+            baseUrl: document.getElementById('baseUrl').value.trim(),
+            token: document.getElementById('token').value.trim(),
+            versionId: document.getElementById('versionId').value.trim(),
+          });
+          document.getElementById('status').textContent = message;
+        } catch (error) {
+          document.getElementById('status').textContent = error.message;
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/nle/resolve/main.js
+++ b/nle/resolve/main.js
@@ -1,0 +1,122 @@
+const { app } = require('electron');
+
+function nearestResolveColor(hex) {
+  const palette = [
+    { name: 'Blue', r: 59, g: 130, b: 246 },
+    { name: 'Red', r: 239, g: 68, b: 68 },
+    { name: 'Green', r: 34, g: 197, b: 94 },
+    { name: 'Yellow', r: 234, g: 179, b: 8 },
+    { name: 'Cyan', r: 6, g: 182, b: 212 },
+    { name: 'Pink', r: 236, g: 72, b: 153 },
+    { name: 'Purple', r: 168, g: 85, b: 247 },
+    { name: 'Orange', r: 249, g: 115, b: 22 },
+  ];
+  if (!hex || !/^#?[0-9a-f]{6}$/i.test(hex)) return 'Blue';
+  const value = hex.replace('#', '');
+  const r = Number.parseInt(value.slice(0, 2), 16);
+  const g = Number.parseInt(value.slice(2, 4), 16);
+  const b = Number.parseInt(value.slice(4, 6), 16);
+  let best = palette[0];
+  let bestDist = Infinity;
+  for (const color of palette) {
+    const dist = (color.r - r) ** 2 + (color.g - g) ** 2 + (color.b - b) ** 2;
+    if (dist < bestDist) {
+      best = color;
+      bestDist = dist;
+    }
+  }
+  return best.name;
+}
+
+function parseCustomData(raw) {
+  if (!raw || typeof raw !== 'string' || !raw.startsWith('{')) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function sequenceStartSeconds(timeline, fps) {
+  try {
+    const tc = timeline.GetStartTimecode?.() || timeline.GetSetting?.('timelineStartTimecode');
+    if (!tc || typeof tc !== 'string') return 0;
+    const match = /^(\d{1,3}):([0-5]\d):([0-5]\d)[:;](\d{1,3})$/.exec(tc.trim());
+    if (!match) return 0;
+    return (
+      Number(match[1]) * 3600 +
+      Number(match[2]) * 60 +
+      Number(match[3]) +
+      Number(match[4]) / Math.max(1, fps)
+    );
+  } catch {
+    return 0;
+  }
+}
+
+async function createWindow() {
+  const { BrowserWindow, ipcMain } = require('electron');
+  const path = require('path');
+  const win = new BrowserWindow({
+    width: 420,
+    height: 640,
+    webPreferences: { nodeIntegration: true, contextIsolation: false },
+  });
+  await win.loadFile(path.join(__dirname, 'index.html'));
+
+  ipcMain.handle('sync', async (_event, { baseUrl, token, versionId }) => {
+    const resolve = app.resolve;
+    if (!resolve) throw new Error('Resolve scripting API is unavailable. Studio is required.');
+    const projectManager = resolve.GetProjectManager();
+    const project = projectManager.GetCurrentProject();
+    if (!project) throw new Error('No project open');
+    const timeline = project.GetCurrentTimeline();
+    if (!timeline) throw new Error('No timeline open');
+
+    const response = await fetch(`${baseUrl.replace(/\/$/, '')}/api/v1/versions/${versionId}/comments`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const payload = await response.json();
+    const comments = (payload.data?.comments ?? []).filter(
+      (comment) => !comment.parentId && !comment.isResolved
+    );
+
+    const fps = Number(timeline.GetSetting('timelineFrameRate')) || 24;
+    const offsetSeconds = sequenceStartSeconds(timeline, fps);
+    const existing = timeline.GetMarkers() || {};
+    const byOfId = new Map();
+    for (const [frame, info] of Object.entries(existing)) {
+      const parsed = parseCustomData(info.customData);
+      if (parsed?.ofId) byOfId.set(parsed.ofId, { frame: Number(frame), info });
+    }
+
+    let added = 0;
+    let skipped = 0;
+    for (const comment of comments) {
+      const frame = Math.round((comment.timestamp + offsetSeconds) * fps);
+      const duration =
+        comment.timestampEnd && comment.timestampEnd > comment.timestamp
+          ? Math.max(1, Math.round((comment.timestampEnd - comment.timestamp) * fps))
+          : 1;
+      const customData = JSON.stringify({ ofId: comment.id, versionId });
+      const color = nearestResolveColor(comment.tag?.color);
+      const name = (comment.content || 'Note').slice(0, 40);
+      const note = comment.content || '';
+      if (byOfId.has(comment.id)) {
+        skipped += 1;
+        continue;
+      }
+      const lookup = timeline.GetMarkerByCustomData?.(customData);
+      if (lookup) {
+        skipped += 1;
+        continue;
+      }
+      const ok = timeline.AddMarker(frame, color, name, note, duration, customData);
+      if (ok) added += 1;
+    }
+    return `Synced ${added} new markers (${skipped} already present).`;
+  });
+}
+
+app.whenReady().then(() => createWindow());

--- a/nle/resolve/package.json
+++ b/nle/resolve/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@openframe/resolve-plugin",
+  "private": true,
+  "type": "module"
+}

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --max-warnings=0 --fix",
+      "eslint --max-warnings=0 --fix --no-warn-ignored",
       "prettier --write"
     ],
     "*.{json,css,md,yml,yaml,mdx}": [

--- a/prisma/migrations/20260828120000_internal_timecode_api_transcript/migration.sql
+++ b/prisma/migrations/20260828120000_internal_timecode_api_transcript/migration.sql
@@ -1,0 +1,155 @@
+-- CreateEnum
+CREATE TYPE "MediaJobKind" AS ENUM ('PROBE_MEDIA', 'EXTRACT_AUDIO', 'TRANSCRIBE');
+
+-- CreateEnum
+CREATE TYPE "MediaJobStatus" AS ENUM ('PENDING', 'QUEUED', 'RUNNING', 'SUCCEEDED', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "TranscriptStatus" AS ENUM ('PENDING', 'RUNNING', 'READY', 'FAILED');
+
+-- AlterTable
+ALTER TABLE "video_versions"
+  ADD COLUMN "frame_rate_num" INTEGER,
+  ADD COLUMN "frame_rate_den" INTEGER,
+  ADD COLUMN "drop_frame" BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN "start_timecode" TEXT,
+  ADD COLUMN "duration_frames" INTEGER;
+
+-- AlterTable
+ALTER TABLE "comments" ADD COLUMN "timestampFrame" INTEGER;
+
+-- CreateTable
+CREATE TABLE "api_tokens" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "token_prefix" TEXT NOT NULL,
+    "last_used_at" TIMESTAMP(3),
+    "expires_at" TIMESTAMP(3),
+    "revoked_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "api_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "media_jobs" (
+    "id" TEXT NOT NULL,
+    "kind" "MediaJobKind" NOT NULL,
+    "status" "MediaJobStatus" NOT NULL DEFAULT 'PENDING',
+    "version_id" TEXT NOT NULL,
+    "payload" JSONB,
+    "error" TEXT,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "started_at" TIMESTAMP(3),
+    "finished_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "media_jobs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "transcripts" (
+    "id" TEXT NOT NULL,
+    "version_id" TEXT NOT NULL,
+    "language" TEXT NOT NULL DEFAULT 'en',
+    "provider" TEXT NOT NULL,
+    "status" "TranscriptStatus" NOT NULL DEFAULT 'PENDING',
+    "search_text" TEXT NOT NULL DEFAULT '',
+    "search_vector" tsvector,
+    "error" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "transcripts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "transcript_segments" (
+    "id" TEXT NOT NULL,
+    "transcript_id" TEXT NOT NULL,
+    "start_sec" DOUBLE PRECISION NOT NULL,
+    "end_sec" DOUBLE PRECISION NOT NULL,
+    "speaker" TEXT,
+    "text" TEXT NOT NULL,
+    "words" JSONB NOT NULL,
+    "position" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "transcript_segments_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sequence_links" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "version_id" TEXT NOT NULL,
+    "nle" TEXT NOT NULL,
+    "sequence_name" TEXT NOT NULL,
+    "start_timecode" TEXT NOT NULL,
+    "frame_rate_num" INTEGER NOT NULL,
+    "frame_rate_den" INTEGER NOT NULL,
+    "drop_frame" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sequence_links_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "api_tokens_token_hash_key" ON "api_tokens"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "api_tokens_userId_idx" ON "api_tokens"("userId");
+
+-- CreateIndex
+CREATE INDEX "media_jobs_status_created_at_idx" ON "media_jobs"("status", "created_at");
+
+-- CreateIndex
+CREATE INDEX "media_jobs_version_id_kind_idx" ON "media_jobs"("version_id", "kind");
+
+-- CreateIndex
+CREATE INDEX "transcripts_version_id_idx" ON "transcripts"("version_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "transcripts_version_id_language_key" ON "transcripts"("version_id", "language");
+
+-- CreateIndex
+CREATE INDEX "transcript_segments_transcript_id_position_idx" ON "transcript_segments"("transcript_id", "position");
+
+-- CreateIndex
+CREATE INDEX "sequence_links_version_id_idx" ON "sequence_links"("version_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sequence_links_user_id_version_id_nle_key" ON "sequence_links"("user_id", "version_id", "nle");
+
+-- CreateIndex
+CREATE INDEX "transcripts_search_vector_idx" ON "transcripts" USING GIN ("search_vector");
+
+-- AddForeignKey
+ALTER TABLE "api_tokens" ADD CONSTRAINT "api_tokens_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "media_jobs" ADD CONSTRAINT "media_jobs_version_id_fkey" FOREIGN KEY ("version_id") REFERENCES "video_versions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "transcripts" ADD CONSTRAINT "transcripts_version_id_fkey" FOREIGN KEY ("version_id") REFERENCES "video_versions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "transcript_segments" ADD CONSTRAINT "transcript_segments_transcript_id_fkey" FOREIGN KEY ("transcript_id") REFERENCES "transcripts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Keep search_vector in sync with search_text so full-text search does not
+-- depend on the application writing both columns.
+CREATE OR REPLACE FUNCTION transcripts_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector := to_tsvector('simple', coalesce(NEW.search_text, ''));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER transcripts_search_vector_trigger
+BEFORE INSERT OR UPDATE OF search_text ON transcripts
+FOR EACH ROW
+EXECUTE FUNCTION transcripts_search_vector_update();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,6 +54,7 @@ model User {
   sentInvitations           Invitation[] @relation("InvitationsSentBy")
   acquisition               UserAcquisition?
   analyticsEvents           AnalyticsEvent[]
+  apiTokens                 ApiToken[]
 
   @@map("users")
 }
@@ -370,6 +371,12 @@ model VideoVersion {
   thumbnailUrl    String?
   duration        Int?     // Duration in seconds
   sizeBytes       BigInt   @default(0) @map("size_bytes") // R2-hosted video file size
+  // Rational frame rate as returned by ffprobe (e.g. 30000/1001). Null until probed.
+  frameRateNum    Int?     @map("frame_rate_num")
+  frameRateDen    Int?     @map("frame_rate_den")
+  dropFrame       Boolean  @default(false) @map("drop_frame")
+  startTimecode   String?  @map("start_timecode")
+  durationFrames  Int?     @map("duration_frames")
   
   // Status
   isActive        Boolean  @default(true) // Currently displayed version
@@ -386,6 +393,8 @@ model VideoVersion {
   watchProgress   WatchProgress[]
   approvalRequests ApprovalRequest[]
   subtitles       VideoSubtitle[]
+  transcripts     Transcript[]
+  mediaJobs       MediaJob[]
   
   @@unique([videoParentId, versionNumber])
   @@index([videoParentId])
@@ -458,6 +467,8 @@ model Comment {
   // Timestamp in video (in seconds, with decimal for precision)
   timestamp     Float       // e.g., 65.5 = 1:05.5
   timestampEnd  Float?      // Optional end timestamp for range comments
+  /// Frame index derived on write when the version has a known frame rate.
+  timestampFrame Int?
   
   // Voice recording (optional)
   voiceUrl      String?     // URL to voice recording file
@@ -902,6 +913,115 @@ model AnalyticsEvent {
   @@index([channel, name, occurredAt])
   @@index([anonymousId])
   @@map("analytics_events")
+}
+
+enum MediaJobKind {
+  PROBE_MEDIA
+  EXTRACT_AUDIO
+  TRANSCRIBE
+}
+
+enum MediaJobStatus {
+  PENDING
+  QUEUED
+  RUNNING
+  SUCCEEDED
+  FAILED
+}
+
+enum TranscriptStatus {
+  PENDING
+  RUNNING
+  READY
+  FAILED
+}
+
+model ApiToken {
+  id          String    @id @default(cuid())
+  userId      String
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  name        String
+  tokenHash   String    @unique @map("token_hash")
+  tokenPrefix String    @map("token_prefix")
+  lastUsedAt  DateTime? @map("last_used_at")
+  expiresAt   DateTime? @map("expires_at")
+  revokedAt   DateTime? @map("revoked_at")
+  createdAt   DateTime  @default(now()) @map("created_at")
+
+  @@index([userId])
+  @@map("api_tokens")
+}
+
+model MediaJob {
+  id         String         @id @default(cuid())
+  kind       MediaJobKind
+  status     MediaJobStatus @default(PENDING)
+  versionId  String         @map("version_id")
+  version    VideoVersion   @relation(fields: [versionId], references: [id], onDelete: Cascade)
+  payload    Json?
+  error      String?        @db.Text
+  attempts   Int            @default(0)
+  startedAt  DateTime?      @map("started_at")
+  finishedAt DateTime?      @map("finished_at")
+  createdAt  DateTime       @default(now()) @map("created_at")
+  updatedAt  DateTime       @updatedAt @map("updated_at")
+
+  @@index([status, createdAt])
+  @@index([versionId, kind])
+  @@map("media_jobs")
+}
+
+model Transcript {
+  id           String            @id @default(cuid())
+  versionId    String            @map("version_id")
+  version      VideoVersion      @relation(fields: [versionId], references: [id], onDelete: Cascade)
+  language     String            @default("en")
+  provider     String
+  status       TranscriptStatus  @default(PENDING)
+  searchText   String            @default("") @db.Text @map("search_text")
+  searchVector Unsupported("tsvector")? @map("search_vector")
+  error        String?           @db.Text
+  createdAt    DateTime          @default(now()) @map("created_at")
+  updatedAt    DateTime          @updatedAt @map("updated_at")
+  segments     TranscriptSegment[]
+
+  @@unique([versionId, language])
+  @@index([versionId])
+  @@map("transcripts")
+}
+
+model TranscriptSegment {
+  id           String     @id @default(cuid())
+  transcriptId String     @map("transcript_id")
+  transcript   Transcript @relation(fields: [transcriptId], references: [id], onDelete: Cascade)
+  startSec     Float      @map("start_sec")
+  endSec       Float      @map("end_sec")
+  speaker      String?
+  text         String     @db.Text
+  words        Json
+  position     Int
+  createdAt    DateTime   @default(now()) @map("created_at")
+
+  @@index([transcriptId, position])
+  @@map("transcript_segments")
+}
+
+model SequenceLink {
+  id            String   @id @default(cuid())
+  userId        String   @map("user_id")
+  versionId     String   @map("version_id")
+  nle           String
+  sequenceName  String   @map("sequence_name")
+  startTimecode String   @map("start_timecode")
+  frameRateNum  Int      @map("frame_rate_num")
+  frameRateDen  Int      @map("frame_rate_den")
+  dropFrame     Boolean  @default(false) @map("drop_frame")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  @@unique([userId, versionId, nle])
+  @@index([versionId])
+  @@map("sequence_links")
 }
 
 // Rate limiting table (created as UNLOGGED via raw SQL migration)

--- a/tests/api/auth-matrix.test.ts
+++ b/tests/api/auth-matrix.test.ts
@@ -78,6 +78,8 @@ import * as projectsRoute from '@/app/api/projects/route';
 import * as searchRoute from '@/app/api/search/route';
 import * as settingsNotificationsRoute from '@/app/api/settings/notifications/route';
 import * as settingsStorageRoute from '@/app/api/settings/storage/route';
+import * as settingsApiTokensRoute from '@/app/api/settings/api-tokens/route';
+import * as settingsApiTokenRoute from '@/app/api/settings/api-tokens/[tokenId]/route';
 import * as uploadAudioFileRoute from '@/app/api/upload/audio/[filename]/route';
 import * as uploadAudioRoute from '@/app/api/upload/audio/route';
 import * as uploadImageFileRoute from '@/app/api/upload/image/[filename]/route';
@@ -88,6 +90,13 @@ import * as versionApprovalsRoute from '@/app/api/versions/[versionId]/approvals
 import * as commentsExportRoute from '@/app/api/versions/[versionId]/comments/export/route';
 import * as versionCommentsRoute from '@/app/api/versions/[versionId]/comments/route';
 import * as versionDownloadRoute from '@/app/api/versions/[versionId]/download/route';
+import * as versionTranscriptRoute from '@/app/api/versions/[versionId]/transcript/route';
+import * as v1ProjectsRoute from '@/app/api/v1/projects/route';
+import * as v1ProjectVideosRoute from '@/app/api/v1/projects/[projectId]/videos/route';
+import * as v1VersionRoute from '@/app/api/v1/versions/[versionId]/route';
+import * as v1VersionCommentsRoute from '@/app/api/v1/versions/[versionId]/comments/route';
+import * as v1VersionTranscriptRoute from '@/app/api/v1/versions/[versionId]/transcript/route';
+import * as v1CommentRoute from '@/app/api/v1/comments/[commentId]/route';
 import * as assetDownloadRoute from '@/app/api/videos/[videoId]/assets/[assetId]/download/route';
 import * as assetRoute from '@/app/api/videos/[videoId]/assets/[assetId]/route';
 import * as assetsBunnyInitRoute from '@/app/api/videos/[videoId]/assets/bunny-init/route';
@@ -148,7 +157,7 @@ vi.mock('@/lib/r2', async (importOriginal) => {
 // The count guard
 // ---------------------------------------------------------------------------
 // Bump this only together with a new entry in ROUTE_CASES or in PUBLIC_ROUTES.
-const EXPECTED_ROUTE_MODULE_COUNT = 66;
+const EXPECTED_ROUTE_MODULE_COUNT = 75;
 
 /**
  * Routes that are public by design, and why. Everything else must reject an
@@ -587,6 +596,63 @@ const ROUTE_CASES: readonly RouteCase[] = [
     file: 'settings/storage/route.ts',
     module: settingsStorageRoute,
     url: () => '/api/settings/storage',
+  },
+  {
+    file: 'settings/api-tokens/route.ts',
+    module: settingsApiTokensRoute,
+    url: () => '/api/settings/api-tokens',
+    body: { name: 'panel' },
+  },
+  {
+    file: 'settings/api-tokens/[tokenId]/route.ts',
+    module: settingsApiTokenRoute,
+    url: (f) => `/api/settings/api-tokens/${f.userId}`,
+    params: (f) => ({ tokenId: f.userId }),
+  },
+  {
+    file: 'v1/projects/route.ts',
+    module: v1ProjectsRoute,
+    url: () => '/api/v1/projects',
+  },
+  {
+    file: 'v1/projects/[projectId]/videos/route.ts',
+    module: v1ProjectVideosRoute,
+    url: (f) => `/api/v1/projects/${f.projectId}/videos`,
+    params: (f) => ({ projectId: f.projectId }),
+  },
+  {
+    file: 'v1/versions/[versionId]/route.ts',
+    module: v1VersionRoute,
+    url: (f) => `/api/v1/versions/${f.versionId}`,
+    params: (f) => ({ versionId: f.versionId }),
+  },
+  {
+    file: 'v1/versions/[versionId]/comments/route.ts',
+    module: v1VersionCommentsRoute,
+    url: (f) => `/api/v1/versions/${f.versionId}/comments`,
+    params: (f) => ({ versionId: f.versionId }),
+    body: { content: 'anon note', timestamp: 1 },
+  },
+  {
+    file: 'v1/versions/[versionId]/transcript/route.ts',
+    module: v1VersionTranscriptRoute,
+    url: (f) => `/api/v1/versions/${f.versionId}/transcript`,
+    params: (f) => ({ versionId: f.versionId }),
+    body: { language: 'en' },
+  },
+  {
+    file: 'v1/comments/[commentId]/route.ts',
+    module: v1CommentRoute,
+    url: (f) => `/api/v1/comments/${f.commentId}`,
+    params: (f) => ({ commentId: f.commentId }),
+    body: { isResolved: true },
+  },
+  {
+    file: 'versions/[versionId]/transcript/route.ts',
+    module: versionTranscriptRoute,
+    url: (f) => `/api/versions/${f.versionId}/transcript`,
+    params: (f) => ({ versionId: f.versionId }),
+    body: { language: 'en' },
   },
   {
     file: 'upload/audio/[filename]/route.ts',

--- a/tests/api/v1.test.ts
+++ b/tests/api/v1.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { GET as listTokens, POST as createToken } from '@/app/api/settings/api-tokens/route';
+import { DELETE as revokeToken } from '@/app/api/settings/api-tokens/[tokenId]/route';
+import { GET as listV1Projects } from '@/app/api/v1/projects/route';
+import {
+  GET as listV1Comments,
+  POST as createV1Comment,
+} from '@/app/api/v1/versions/[versionId]/comments/route';
+import { db } from '@/lib/db';
+import { hashApiToken } from '@/lib/api-token';
+import { apiRequest, callRoute, readData, readError } from '../helpers/request';
+import { signedInAs, signedOut } from '../helpers/session';
+import {
+  createProject,
+  createUser,
+  createVersion,
+  createVideo,
+  createWorkspace,
+} from '../factories';
+
+async function seedOwnedVersion() {
+  const user = await createUser();
+  const workspace = await createWorkspace({ ownerId: user.id });
+  const project = await createProject({ ownerId: user.id, workspaceId: workspace.id });
+  const video = await createVideo({ projectId: project.id });
+  const version = await createVersion({ videoParentId: video.id, duration: 60 });
+  return { user, project, version };
+}
+
+describe('API tokens', () => {
+  it('refuses an anonymous caller', async () => {
+    signedOut();
+    const response = await callRoute(listTokens, apiRequest('/api/settings/api-tokens'));
+    expect(response.status).toBe(401);
+  });
+
+  it('creates a token, returns the secret once, and authenticates v1 with it', async () => {
+    const { user, project, version } = await seedOwnedVersion();
+    signedInAs(user);
+
+    const created = await callRoute(
+      createToken,
+      apiRequest('/api/settings/api-tokens', { method: 'POST', body: { name: 'panel' } })
+    );
+    expect(created.status).toBe(201);
+    const payload = await readData<{ token: { id: string; secret: string; tokenPrefix: string } }>(
+      created
+    );
+    expect(payload.token.secret.startsWith('of_live_')).toBe(true);
+
+    const listed = await callRoute(listTokens, apiRequest('/api/settings/api-tokens'));
+    const listedData = await readData<{ tokens: Array<{ id: string; tokenPrefix: string }> }>(
+      listed
+    );
+    expect(listedData.tokens).toHaveLength(1);
+    expect(listedData.tokens[0].tokenPrefix).toBe(payload.token.tokenPrefix);
+
+    signedOut();
+    const v1 = await callRoute(
+      listV1Projects,
+      apiRequest('/api/v1/projects', {
+        headers: { authorization: `Bearer ${payload.token.secret}` },
+      })
+    );
+    expect(v1.status).toBe(200);
+    const projects = await readData<{ projects: Array<{ id: string }> }>(v1);
+    expect(projects.projects.map((row) => row.id)).toContain(project.id);
+
+    const commentRes = await callRoute(
+      createV1Comment,
+      apiRequest(`/api/v1/versions/${version.id}/comments`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${payload.token.secret}` },
+        body: { content: 'From the panel', timestamp: 1.25 },
+      }),
+      { versionId: version.id }
+    );
+    expect(commentRes.status).toBe(201);
+
+    const listedComments = await callRoute(
+      listV1Comments,
+      apiRequest(`/api/v1/versions/${version.id}/comments`, {
+        headers: { authorization: `Bearer ${payload.token.secret}` },
+      }),
+      { versionId: version.id }
+    );
+    expect(listedComments.status).toBe(200);
+    const comments = await readData<{ comments: Array<{ content: string | null }> }>(
+      listedComments
+    );
+    expect(comments.comments.some((row) => row.content === 'From the panel')).toBe(true);
+
+    signedInAs(user);
+    const revoked = await callRoute(
+      revokeToken,
+      apiRequest(`/api/settings/api-tokens/${payload.token.id}`, { method: 'DELETE' }),
+      { tokenId: payload.token.id }
+    );
+    expect(revoked.status).toBe(200);
+
+    signedOut();
+    const afterRevoke = await callRoute(
+      listV1Projects,
+      apiRequest('/api/v1/projects', {
+        headers: { authorization: `Bearer ${payload.token.secret}` },
+      })
+    );
+    expect(afterRevoke.status).toBe(401);
+
+    const stored = await db.apiToken.findUnique({ where: { id: payload.token.id } });
+    expect(stored?.tokenHash).toBe(hashApiToken(payload.token.secret));
+    expect(stored?.revokedAt).not.toBeNull();
+  });
+
+  it('does not mint a token with an empty name', async () => {
+    const user = await createUser();
+    signedInAs(user);
+    const response = await callRoute(
+      createToken,
+      apiRequest('/api/settings/api-tokens', { method: 'POST', body: { name: '   ' } })
+    );
+    expect(response.status).toBe(400);
+    expect(await readError(response)).toMatch(/name/i);
+  });
+});

--- a/tests/setup/db-global.ts
+++ b/tests/setup/db-global.ts
@@ -70,14 +70,16 @@ const REVIEWED_MIGRATIONS = [
   '20260818120000_add_upload_reservation_purpose',
   '20260820120000_add_comment_images',
   '20260822120000_add_video_subtitles',
+  '20260828120000_internal_timecode_api_transcript', // replayed: tsvector GIN + trigger
 ];
 
 /** Objects POST_PUSH_SQL must have produced. Verified after it runs. */
-const REQUIRED_FUNCTIONS = ['cleanup_rate_limits'];
+const REQUIRED_FUNCTIONS = ['cleanup_rate_limits', 'transcripts_search_vector_update'];
 const REQUIRED_INDEXES = [
   'video_versions_r2_videoid_unique',
   'video_versions_r2_originalurl_unique',
   'video_versions_r2_thumbnail_unique',
+  'transcripts_search_vector_idx',
 ];
 
 const POST_PUSH_SQL = `
@@ -118,6 +120,24 @@ WHERE "providerId" = 'r2' AND "originalUrl" LIKE '/api/upload/video/%';
 CREATE UNIQUE INDEX IF NOT EXISTS "video_versions_r2_thumbnail_unique"
 ON "video_versions" ("thumbnailUrl")
 WHERE "providerId" = 'r2' AND "thumbnailUrl" LIKE '/api/upload/image/%';
+
+-- Replayed from 20260828120000_internal_timecode_api_transcript. The GIN index
+-- and search_vector trigger are not expressible in schema.prisma.
+CREATE INDEX IF NOT EXISTS "transcripts_search_vector_idx"
+ON "transcripts" USING GIN ("search_vector");
+
+CREATE OR REPLACE FUNCTION transcripts_search_vector_update() RETURNS trigger AS $$
+BEGIN
+  NEW.search_vector := to_tsvector('simple', coalesce(NEW.search_text, ''));
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS transcripts_search_vector_trigger ON transcripts;
+CREATE TRIGGER transcripts_search_vector_trigger
+BEFORE INSERT OR UPDATE OF search_text ON transcripts
+FOR EACH ROW
+EXECUTE FUNCTION transcripts_search_vector_update();
 `;
 
 function assertMigrationsReviewed(): void {

--- a/tests/unit/lib/api-token.test.ts
+++ b/tests/unit/lib/api-token.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { extractBearerToken, generateApiToken, hashApiToken } from '@/lib/api-token';
+
+describe('generateApiToken', () => {
+  it('returns a of_live_ token whose hash matches hashApiToken', () => {
+    const token = generateApiToken();
+    expect(token.raw.startsWith('of_live_')).toBe(true);
+    expect(token.hash).toBe(hashApiToken(token.raw));
+    expect(token.prefix).toBe(token.raw.slice(0, 'of_live_'.length + 8));
+    expect(token.hash).toHaveLength(64);
+  });
+
+  it('never repeats', () => {
+    expect(generateApiToken().raw).not.toBe(generateApiToken().raw);
+  });
+});
+
+describe('extractBearerToken', () => {
+  it('reads a well-formed header', () => {
+    const token = generateApiToken().raw;
+    expect(extractBearerToken(`Bearer ${token}`)).toBe(token);
+    expect(extractBearerToken(`bearer ${token}`)).toBe(token);
+  });
+
+  it('rejects missing, short, or non-bearer values', () => {
+    expect(extractBearerToken(null)).toBeNull();
+    expect(extractBearerToken('Basic abc')).toBeNull();
+    expect(extractBearerToken('Bearer short')).toBeNull();
+    expect(extractBearerToken('Bearer of_live_abcd')).toBeNull();
+  });
+});

--- a/tests/unit/lib/comment-export.test.ts
+++ b/tests/unit/lib/comment-export.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildCommentsCsv,
+  buildCommentsEdl,
+  buildCommentsFcpxml,
   buildCommentsPdf,
   buildExportFileBaseName,
   flattenCommentsForExport,
@@ -438,5 +440,50 @@ describe('buildCommentsPdf', () => {
 
     expect(chunks.length).toBeGreaterThan(1);
     expect(chunks.every((chunk) => chunk.length <= 96)).toBe(true);
+  });
+});
+
+const MARKER_META = {
+  videoTitle: 'My Video',
+  versionNumber: 2,
+  versionLabel: 'Rough cut',
+  frameRate: { num: 24, den: 1, dropFrame: false },
+  startTimecode: null,
+  durationSeconds: 120,
+};
+
+describe('buildCommentsEdl', () => {
+  it('writes a CMX-style event per top-level comment', () => {
+    const edl = buildCommentsEdl([row({ timestamp: 1, content: 'Fix this' })], MARKER_META);
+    expect(edl).toContain('TITLE: My Video v2');
+    expect(edl).toContain('FCM: NON-DROP FRAME');
+    expect(edl).toContain('001  AX      V     C        00:00:01:00');
+    expect(edl).toContain('* FROM Alice: Fix this');
+  });
+
+  it('skips replies as their own events', () => {
+    const edl = buildCommentsEdl(
+      [row({ level: 0 }), row({ commentId: 'r1', parentCommentId: 'comment-1', level: 1 })],
+      MARKER_META
+    );
+    expect(edl).toContain('001  AX');
+    expect(edl).not.toContain('002  AX');
+  });
+});
+
+describe('buildCommentsFcpxml', () => {
+  it('embeds a marker whose start is a rational time', () => {
+    const xml = buildCommentsFcpxml([row({ timestamp: 1, content: 'Fix this' })], MARKER_META);
+    expect(xml).toContain('<?xml version="1.0"');
+    expect(xml).toContain('fcpxml version="1.9"');
+    expect(xml).toContain('start="24/24s"');
+    expect(xml).toContain('Alice: Fix this');
+    expect(xml).toContain('tcFormat="NDF"');
+  });
+
+  it('escapes XML in comment text', () => {
+    const xml = buildCommentsFcpxml([row({ content: 'A <cut> & "quote"' })], MARKER_META);
+    expect(xml).toContain('A &lt;cut&gt; &amp; &quot;quote&quot;');
+    expect(xml).not.toContain('A <cut>');
   });
 });

--- a/tests/unit/lib/nle-sync.test.ts
+++ b/tests/unit/lib/nle-sync.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commentSentinel,
+  nearestResolveColor,
+  parseSentinel,
+  reconcile,
+} from '../../../nle/core/src/index';
+
+describe('sentinel', () => {
+  it('round-trips a comment id', () => {
+    expect(parseSentinel(`note\n${commentSentinel('abc123')}`)).toBe('abc123');
+    expect(parseSentinel('plain marker')).toBeNull();
+  });
+});
+
+describe('reconcile', () => {
+  const remote = [
+    {
+      id: 'c1',
+      content: 'Fix this',
+      timestamp: 1.5,
+      timestampEnd: null,
+      timestampFrame: 36,
+      isResolved: false,
+      parentId: null,
+      author: { name: 'Ada' },
+      guestName: null,
+      tag: null,
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    },
+  ];
+
+  it('adds a comment that has no marker', () => {
+    const plan = reconcile(remote, []);
+    expect(plan.add.map((row) => row.id)).toEqual(['c1']);
+    expect(plan.move).toEqual([]);
+    expect(plan.remove).toEqual([]);
+  });
+
+  it('moves a marker that drifted', () => {
+    const plan = reconcile(remote, [
+      {
+        id: 'm1',
+        commentId: 'c1',
+        startSeconds: 4,
+        durationSeconds: 0,
+        name: 'old',
+        comments: commentSentinel('c1'),
+      },
+    ]);
+    expect(plan.add).toEqual([]);
+    expect(plan.move).toHaveLength(1);
+  });
+
+  it('removes a marker whose comment is gone', () => {
+    const plan = reconcile(
+      [],
+      [
+        {
+          id: 'm1',
+          commentId: 'gone',
+          startSeconds: 1,
+          durationSeconds: 0,
+          name: 'stale',
+          comments: commentSentinel('gone'),
+        },
+      ]
+    );
+    expect(plan.remove).toHaveLength(1);
+  });
+
+  it('ignores resolved and reply comments', () => {
+    const plan = reconcile(
+      [
+        { ...remote[0], isResolved: true },
+        { ...remote[0], id: 'r1', parentId: 'c1' },
+      ],
+      []
+    );
+    expect(plan.add).toEqual([]);
+  });
+});
+
+describe('nearestResolveColor', () => {
+  it('maps a blue hex to Blue', () => {
+    expect(nearestResolveColor('#3B82F6')).toBe('Blue');
+  });
+
+  it('falls back when the value is missing', () => {
+    expect(nearestResolveColor(null)).toBe('Blue');
+  });
+});

--- a/tests/unit/lib/timecode.test.ts
+++ b/tests/unit/lib/timecode.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commentSecondsToSequenceFrames,
+  deriveTimestampFrame,
+  framesToSeconds,
+  framesToTimecode,
+  parseFrameRateString,
+  parseTimecode,
+  reduceFrameRate,
+  secondsToFrames,
+  secondsToTimecode,
+  timecodeToFrames,
+} from '@/lib/timecode';
+
+const F24 = { num: 24, den: 1, dropFrame: false };
+const F25 = { num: 25, den: 1, dropFrame: false };
+const NTSC = { num: 30000, den: 1001, dropFrame: true };
+
+describe('reduceFrameRate', () => {
+  it('reduces 48000/2002 to 24000/1001', () => {
+    expect(reduceFrameRate(48000, 2002)).toEqual({ num: 24000, den: 1001 });
+  });
+
+  it('leaves 25/1 alone', () => {
+    expect(reduceFrameRate(25, 1)).toEqual({ num: 25, den: 1 });
+  });
+});
+
+describe('parseFrameRateString', () => {
+  it('parses ffprobe r_frame_rate', () => {
+    expect(parseFrameRateString('30000/1001')).toEqual({ num: 30000, den: 1001 });
+  });
+
+  it('rejects junk', () => {
+    expect(parseFrameRateString('29.97')).toBeNull();
+    expect(parseFrameRateString('0/1')).toBeNull();
+  });
+});
+
+describe('secondsToFrames / framesToSeconds', () => {
+  it('maps 1 second of 24fps to frame 24', () => {
+    expect(secondsToFrames(1, F24)).toBe(24);
+    expect(framesToSeconds(24, F24)).toBe(1);
+  });
+
+  it('does not drift on NTSC: 10 minutes is 17982 frames of 29.97 DF', () => {
+    const tenMinutes = 10 * 60;
+    const frames = secondsToFrames(tenMinutes, NTSC);
+    expect(frames).toBe(17982);
+  });
+
+  it('deriveTimestampFrame returns null without a rate', () => {
+    expect(deriveTimestampFrame(1.5, null, null)).toBeNull();
+    expect(deriveTimestampFrame(1.5, 24, 1)).toBe(36);
+  });
+});
+
+describe('timecode', () => {
+  it('formats NDF 24fps', () => {
+    expect(framesToTimecode(24, F24)).toBe('00:00:01:00');
+    expect(secondsToTimecode(65.5, F24)).toBe('00:01:05:12');
+  });
+
+  it('round-trips NDF 25fps', () => {
+    const tc = '01:02:03:04';
+    const frames = timecodeToFrames(tc, F25);
+    expect(frames).toBe(1 * 3600 * 25 + 2 * 60 * 25 + 3 * 25 + 4);
+    expect(framesToTimecode(frames!, F25)).toBe(tc);
+  });
+
+  it('formats drop-frame 29.97 at 00:01:00;02 (two frames dropped)', () => {
+    const oneMinuteNominal = 30 * 60;
+    expect(framesToTimecode(oneMinuteNominal, NTSC)).toBe('00:01:00;02');
+  });
+
+  it('round-trips a drop-frame timecode away from the drop boundary', () => {
+    const tc = '01:00:00;00';
+    const frames = timecodeToFrames(tc, NTSC);
+    expect(frames).not.toBeNull();
+    expect(framesToTimecode(frames!, NTSC)).toBe(tc);
+  });
+
+  it('parses both separators', () => {
+    expect(parseTimecode('01:02:03:04')?.dropFrame).toBe(false);
+    expect(parseTimecode('01:02:03;04')?.dropFrame).toBe(true);
+    expect(parseTimecode('not a timecode')).toBeNull();
+  });
+});
+
+describe('commentSecondsToSequenceFrames', () => {
+  it('adds the sequence start offset', () => {
+    const offset = { startTimecode: '01:00:00:00', rate: F24 };
+    const frames = commentSecondsToSequenceFrames(2, offset);
+    expect(frames).toBe(timecodeToFrames('01:00:00:00', F24)! + 48);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "prisma/seed.ts"]
+  "exclude": ["node_modules", "prisma/seed.ts", "worker", "nle"]
 }

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,17 @@
+FROM docker.io/oven/bun:1
+
+WORKDIR /worker
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg python3 python3-pip python3-venv \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip3 install --break-system-packages --no-cache-dir faster-whisper \
+  || echo "faster-whisper install skipped; local transcription will fail until it is present"
+
+COPY package.json ./
+RUN bun install
+
+COPY src ./src
+COPY whisper_local.py ./whisper_local.py
+
+CMD ["bun", "run", "start"]

--- a/worker/bun.lock
+++ b/worker/bun.lock
@@ -1,0 +1,133 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "openframe-media-worker",
+      "dependencies": {
+        "@aws-sdk/client-s3": "3.1054.0",
+        "pg": "^8.18.0",
+        "pg-boss": "^10.3.3",
+      },
+    },
+  },
+  "packages": {
+    "@aws-crypto/sha1-browser": ["@aws-crypto/sha1-browser@5.2.0", "", { "dependencies": { "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.29", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A=="],
+
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1054.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.14", "@aws-sdk/credential-provider-node": "^3.972.45", "@aws-sdk/middleware-bucket-endpoint": "^3.972.16", "@aws-sdk/middleware-expect-continue": "^3.972.13", "@aws-sdk/middleware-flexible-checksums": "^3.974.22", "@aws-sdk/middleware-location-constraint": "^3.972.11", "@aws-sdk/middleware-sdk-s3": "^3.972.43", "@aws-sdk/middleware-ssec": "^3.972.11", "@aws-sdk/signature-v4-multi-region": "^3.996.29", "@aws-sdk/types": "^3.973.9", "@smithy/core": "^3.24.3", "@smithy/fetch-http-handler": "^5.4.3", "@smithy/node-http-handler": "^4.7.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-2ue7uVqaHYX4rytkcrLySYU/m/ZlRbL8KojWefbR24B0/TcFkqN2IovpBFrnmla/dtZAn9eVSlhHeEddOghZ5w=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.9", "", { "dependencies": { "@aws-sdk/types": "^3.974.5", "@aws-sdk/xml-builder": "^3.972.40", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.33.3", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.17.2", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.70", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.72", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/fetch-http-handler": "^5.7.2", "@smithy/node-http-handler": "^4.11.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.15", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/credential-provider-env": "^3.972.70", "@aws-sdk/credential-provider-http": "^3.972.72", "@aws-sdk/credential-provider-login": "^3.972.77", "@aws-sdk/credential-provider-process": "^3.972.70", "@aws-sdk/credential-provider-sso": "^3.973.14", "@aws-sdk/credential-provider-web-identity": "^3.972.76", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.77", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.81", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.70", "@aws-sdk/credential-provider-http": "^3.972.72", "@aws-sdk/credential-provider-ini": "^3.973.15", "@aws-sdk/credential-provider-process": "^3.972.70", "@aws-sdk/credential-provider-sso": "^3.973.14", "@aws-sdk/credential-provider-web-identity": "^3.972.76", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.70", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.14", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/token-providers": "3.1116.0", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.76", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA=="],
+
+    "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.48", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.75", "tslib": "^2.6.2" } }, "sha512-2+aR/JVjJW45Sc0ggz0YnG+GTKfkTu69E4XPK8A6OlcJPuL4UAP9p8W7RO4eqSKJBC/SN6U7dJx6Jo7UzP1xeA=="],
+
+    "@aws-sdk/middleware-expect-continue": ["@aws-sdk/middleware-expect-continue@3.972.44", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.75", "tslib": "^2.6.2" } }, "sha512-be6UCy+xLb3jN/lLgSpNcEaXPEo99cfn1AvcP/vMdgOB5OCys692GaBOQAERlxa0pLdnkeMMHorMvlLvm7aTJw=="],
+
+    "@aws-sdk/middleware-flexible-checksums": ["@aws-sdk/middleware-flexible-checksums@3.974.54", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.29", "tslib": "^2.6.2" } }, "sha512-cDplgLpXZy7MfREXbAeOm8PFT8ibjD5B5rbqxocFR/5rdSbXUPURIAvRToVqjcOR5gHYbEkndKAs+Zw7FfZj1A=="],
+
+    "@aws-sdk/middleware-location-constraint": ["@aws-sdk/middleware-location-constraint@3.972.41", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.75", "tslib": "^2.6.2" } }, "sha512-dDpQ0Zrci8sYYaWnZo9puRy0P9dZ0paeIQY6IyebZmmAyZ31+ucS0wTcWhYtfdjS7/JNcKuKkgaknOxfV1aDSg=="],
+
+    "@aws-sdk/middleware-sdk-s3": ["@aws-sdk/middleware-sdk-s3@3.972.75", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/signature-v4-multi-region": "^3.996.46", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng=="],
+
+    "@aws-sdk/middleware-ssec": ["@aws-sdk/middleware-ssec@3.972.41", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.75", "tslib": "^2.6.2" } }, "sha512-AcvMfeSM5/kN23A7W889hVj8mIJ/nlxeJfenVrNDEv9pBvne4/0KfGsdW6qnU7n5xd3HUue49DvtL6eXmFvxTQ=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.44", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/signature-v4-multi-region": "^3.996.46", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/fetch-http-handler": "^5.7.2", "@smithy/node-http-handler": "^4.11.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.46", "", { "dependencies": { "@aws-sdk/types": "^3.974.5", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1116.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.9", "@aws-sdk/nested-clients": "^3.997.44", "@aws-sdk/types": "^3.974.5", "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.5", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.10", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.40", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
+
+    "@smithy/core": ["@smithy/core@3.33.3", "", { "dependencies": { "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.5.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.7.2", "", { "dependencies": { "@smithy/core": "^3.33.2", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.11.3", "", { "dependencies": { "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.7.3", "", { "dependencies": { "@smithy/core": "^3.33.3", "@smithy/types": "^4.17.2", "tslib": "^2.6.2" } }, "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow=="],
+
+    "@smithy/types": ["@smithy/types@4.17.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
+    "pg": ["pg@8.23.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.16.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-Ip2EQCngowJLGOfCwkFhPXU7/ljlhn6Rxlmy4XYfL2Y+vyRM59+8uR2xqRWKdYmbXmxCFOAmKxBuSUCdF34qLg=="],
+
+    "pg-boss": ["pg-boss@10.4.2", "", { "dependencies": { "cron-parser": "^4.9.0", "pg": "^8.16.3", "serialize-error": "^8.1.0" } }, "sha512-AttEWOtSzn53av8OnCMWEanwRBvjkZCE1y5nLrZnwvkkMnlZ5XpWDpZ7sKI/BYjvi2OVieMX37arD2ACgJ750w=="],
+
+    "pg-cloudflare": ["pg-cloudflare@1.4.0", "", {}, "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A=="],
+
+    "pg-connection-string": ["pg-connection-string@2.14.0", "", {}, "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg=="],
+
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-pool": ["pg-pool@3.14.0", "", { "peerDependencies": { "pg": ">=8.0" } }, "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw=="],
+
+    "pg-protocol": ["pg-protocol@1.16.0", "", {}, "sha512-sILXutLVjCLjcDuOmvhX5e2Z4cS5qG/6Bu3VkpFwdf/633ElGLpEh9bgmuI5I4sqKqkifQiGyiCcx1HdtrK7tg=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
+    "pgpass": ["pgpass@1.0.5", "", { "dependencies": { "split2": "^4.1.0" } }, "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
+
+    "serialize-error": ["serialize-error@8.1.0", "", { "dependencies": { "type-fest": "^0.20.2" } }, "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
+
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+  }
+}

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "openframe-media-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "dev": "bun --watch src/index.ts"
+  },
+  "dependencies": {
+    "pg": "^8.18.0",
+    "@aws-sdk/client-s3": "3.1054.0",
+    "pg-boss": "^10.3.3"
+  }
+}

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,0 +1,432 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import PgBoss from 'pg-boss';
+import pg from 'pg';
+
+const { Pool } = pg;
+
+function parseFrameRateString(value: string): { num: number; den: number } | null {
+  const match = /^(\d+)\s*\/\s*(\d+)$/.exec(value.trim());
+  if (!match) return null;
+  const num = Number(match[1]);
+  const den = Number(match[2]);
+  if (!Number.isInteger(num) || !Number.isInteger(den) || num <= 0 || den <= 0) return null;
+  let x = num;
+  let y = den;
+  while (y !== 0) {
+    const next = x % y;
+    x = y;
+    y = next;
+  }
+  const divisor = x === 0 ? 1 : x;
+  return { num: num / divisor, den: den / divisor };
+}
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+const R2_BUCKET_NAME = process.env.R2_BUCKET_NAME ?? '';
+const R2_ENDPOINT = process.env.R2_ENDPOINT;
+const R2_ACCOUNT_ID = process.env.R2_ACCOUNT_ID;
+const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID ?? '';
+const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY ?? '';
+
+function s3Endpoint(): string {
+  if (R2_ENDPOINT) return R2_ENDPOINT.replace(/\/+$/, '');
+  if (!R2_ACCOUNT_ID) throw new Error('Missing R2_ENDPOINT or R2_ACCOUNT_ID');
+  return `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`;
+}
+
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: s3Endpoint(),
+  forcePathStyle: Boolean(R2_ENDPOINT),
+  credentials: {
+    accessKeyId: R2_ACCESS_KEY_ID,
+    secretAccessKey: R2_SECRET_ACCESS_KEY,
+  },
+});
+
+function run(command: string, args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ stdout, stderr, code: code ?? 1 }));
+  });
+}
+
+async function downloadObject(key: string, dest: string): Promise<void> {
+  const response = await s3.send(new GetObjectCommand({ Bucket: R2_BUCKET_NAME, Key: key }));
+  if (!response.Body) throw new Error(`Empty object ${key}`);
+  const bytes = await response.Body.transformToByteArray();
+  await writeFile(dest, bytes);
+}
+
+async function uploadObject(key: string, body: Buffer, contentType: string): Promise<void> {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: R2_BUCKET_NAME,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+    })
+  );
+}
+
+function objectKeyFromProvider(version: { providerId: string; videoId: string; originalUrl: string }): string | null {
+  if (version.providerId === 'r2') {
+    if (version.videoId.startsWith('videos/')) return version.videoId;
+    const match = /\/api\/upload\/video\/([^/?]+)$/.exec(version.originalUrl);
+    if (match) return `videos/${match[1]}`;
+  }
+  return null;
+}
+
+async function probeMedia(versionId: string): Promise<void> {
+  const versionRes = await pool.query(
+    `SELECT id, "providerId", "videoId", "originalUrl" FROM video_versions WHERE id = $1`,
+    [versionId]
+  );
+  const version = versionRes.rows[0];
+  if (!version) throw new Error('Version not found');
+  const key = objectKeyFromProvider(version);
+  if (!key) throw new Error('Version has no probeable file');
+
+  const dir = await mkdtemp(join(tmpdir(), 'of-probe-'));
+  const filePath = join(dir, 'source.bin');
+  try {
+    await downloadObject(key, filePath);
+    const probed = await run('ffprobe', [
+      '-v',
+      'error',
+      '-select_streams',
+      'v:0',
+      '-show_entries',
+      'stream=r_frame_rate,nb_frames,duration,avg_frame_rate',
+      '-of',
+      'json',
+      filePath,
+    ]);
+    if (probed.code !== 0) throw new Error(probed.stderr || 'ffprobe failed');
+    const parsed = JSON.parse(probed.stdout) as {
+      streams?: Array<{ r_frame_rate?: string; avg_frame_rate?: string; duration?: string; nb_frames?: string }>;
+    };
+    const stream = parsed.streams?.[0];
+    const rate = parseFrameRateString(stream?.r_frame_rate || stream?.avg_frame_rate || '');
+    const duration = stream?.duration ? Number(stream.duration) : null;
+    const durationFrames = rate && duration ? Math.round((duration * rate.num) / rate.den) : null;
+    const dropFrame = Boolean(rate && ((rate.num === 30000 && rate.den === 1001) || (rate.num === 60000 && rate.den === 1001)));
+
+    await pool.query(
+      `UPDATE video_versions
+       SET frame_rate_num = $2, frame_rate_den = $3, drop_frame = $4, duration_frames = $5,
+           duration = COALESCE(duration, $6)
+       WHERE id = $1`,
+      [versionId, rate?.num ?? null, rate?.den ?? null, dropFrame, durationFrames, duration ? Math.round(duration) : null]
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function extractAudio(versionId: string): Promise<void> {
+  const versionRes = await pool.query(
+    `SELECT id, "providerId", "videoId", "originalUrl" FROM video_versions WHERE id = $1`,
+    [versionId]
+  );
+  const version = versionRes.rows[0];
+  if (!version) throw new Error('Version not found');
+  const key = objectKeyFromProvider(version);
+  if (!key) throw new Error('Version has no extractable file');
+
+  const dir = await mkdtemp(join(tmpdir(), 'of-audio-'));
+  const source = join(dir, 'source.bin');
+  const wav = join(dir, 'audio.wav');
+  try {
+    await downloadObject(key, source);
+    const extracted = await run('ffmpeg', ['-y', '-i', source, '-vn', '-ac', '1', '-ar', '16000', wav]);
+    if (extracted.code !== 0) throw new Error(extracted.stderr || 'ffmpeg failed');
+    const audio = await readFile(wav);
+    await uploadObject(`audio/${versionId}.wav`, audio, 'audio/wav');
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+function toVttTime(seconds: number): string {
+  const clamped = Math.max(0, seconds);
+  const hours = Math.floor(clamped / 3600);
+  const minutes = Math.floor((clamped % 3600) / 60);
+  const secs = Math.floor(clamped % 60);
+  const millis = Math.round((clamped - Math.floor(clamped)) * 1000);
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:${String(secs).padStart(2, '0')}.${String(millis).padStart(3, '0')}`;
+}
+
+function serializeWebVtt(
+  segments: Array<{ start: number; end: number; text: string }>
+): string {
+  const body = segments
+    .map((segment) => `${toVttTime(segment.start)} --> ${toVttTime(segment.end)}\n${segment.text}`)
+    .join('\n\n');
+  return `WEBVTT\n\n${body}\n`;
+}
+
+async function upsertCaptionTrack(
+  versionId: string,
+  language: string,
+  vtt: string
+): Promise<void> {
+  const owner = await pool.query(
+    `SELECT p."ownerId" AS owner_id
+     FROM video_versions vv
+     JOIN videos v ON v.id = vv."videoParentId"
+     JOIN projects p ON p.id = v."projectId"
+     WHERE vv.id = $1`,
+    [versionId]
+  );
+  const billedUserId = owner.rows[0]?.owner_id as string | undefined;
+  if (!billedUserId) return;
+
+  const filename = `${randomUUID()}.vtt`;
+  const sourceUrl = `/api/upload/subtitle/${filename}`;
+  const body = Buffer.from(vtt, 'utf8');
+  await uploadObject(`subtitles/${filename}`, body, 'text/vtt');
+
+  const existing = await pool.query(
+    `SELECT id FROM video_subtitles WHERE "versionId" = $1 AND language = $2`,
+    [versionId, language]
+  );
+  const label = `Transcript (${language})`;
+  if (existing.rows[0]) {
+    await pool.query(
+      `UPDATE video_subtitles
+       SET "sourceUrl" = $2, size_bytes = $3, label = $4, "updatedAt" = NOW()
+       WHERE id = $1`,
+      [existing.rows[0].id, sourceUrl, body.length, label]
+    );
+    return;
+  }
+  await pool.query(
+    `INSERT INTO video_subtitles
+       (id, "versionId", language, label, "sourceUrl", size_bytes, "billedUserId", "createdAt", "updatedAt")
+     VALUES (gen_random_uuid()::text, $1, $2, $3, $4, $5, $6, NOW(), NOW())`,
+    [versionId, language, label, sourceUrl, body.length, billedUserId]
+  );
+}
+
+async function transcribe(versionId: string, payload: { language?: string; transcriptId?: string } | null): Promise<void> {
+  const provider = (process.env.OPENFRAME_TRANSCRIPTION_PROVIDER || 'whisper-local').trim().toLowerCase();
+  const language = payload?.language || 'en';
+
+  const audioKey = `audio/${versionId}.wav`;
+  const dir = await mkdtemp(join(tmpdir(), 'of-tr-'));
+  const wav = join(dir, 'audio.wav');
+  try {
+    try {
+      await downloadObject(audioKey, wav);
+    } catch {
+      await extractAudio(versionId);
+      await downloadObject(audioKey, wav);
+    }
+
+    let result: { language: string; segments: Array<{ start: number; end: number; text: string; words: unknown }> };
+    if (provider === 'whisper-local') {
+      const script = join(import.meta.dir, '..', 'whisper_local.py');
+      const ran = await run('python3', [script, wav, language]);
+      if (ran.code !== 0) throw new Error(ran.stderr || 'faster-whisper failed');
+      result = JSON.parse(ran.stdout);
+    } else {
+      throw new Error(`Provider ${provider} must be run through the app process; worker only supports whisper-local`);
+    }
+
+    const searchText = result.segments.map((segment) => segment.text).join(' ');
+    const upsert = await pool.query(
+      `INSERT INTO transcripts (id, version_id, language, provider, status, search_text, error, created_at, updated_at)
+       VALUES (gen_random_uuid()::text, $1, $2, $3, 'READY', $4, NULL, NOW(), NOW())
+       ON CONFLICT (version_id, language)
+       DO UPDATE SET provider = EXCLUDED.provider, status = 'READY', search_text = EXCLUDED.search_text, error = NULL, updated_at = NOW()
+       RETURNING id`,
+      [versionId, result.language || language, provider, searchText]
+    );
+    const transcriptId = upsert.rows[0].id as string;
+    await pool.query(`DELETE FROM transcript_segments WHERE transcript_id = $1`, [transcriptId]);
+    for (let index = 0; index < result.segments.length; index += 1) {
+      const segment = result.segments[index];
+      await pool.query(
+        `INSERT INTO transcript_segments (id, transcript_id, start_sec, end_sec, speaker, text, words, position, created_at)
+         VALUES (gen_random_uuid()::text, $1, $2, $3, NULL, $4, $5::jsonb, $6, NOW())`,
+        [transcriptId, segment.start, segment.end, segment.text, JSON.stringify(segment.words ?? []), index]
+      );
+    }
+
+    try {
+      await upsertCaptionTrack(versionId, result.language || language, serializeWebVtt(result.segments));
+    } catch (error) {
+      console.error('caption upsert failed', error);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+const QUEUE = {
+  PROBE_MEDIA: 'probe-media',
+  EXTRACT_AUDIO: 'extract-audio',
+  TRANSCRIBE: 'transcribe',
+} as const;
+
+type MediaJobData = {
+  mediaJobId: string;
+  versionId: string;
+  payload: unknown;
+};
+
+function queueForKind(kind: string): string {
+  if (kind === 'PROBE_MEDIA') return QUEUE.PROBE_MEDIA;
+  if (kind === 'EXTRACT_AUDIO') return QUEUE.EXTRACT_AUDIO;
+  if (kind === 'TRANSCRIBE') return QUEUE.TRANSCRIBE;
+  throw new Error(`Unknown job kind ${kind}`);
+}
+
+async function markJob(id: string, status: 'QUEUED' | 'RUNNING' | 'SUCCEEDED' | 'FAILED', error?: string) {
+  if (status === 'QUEUED') {
+    await pool.query(`UPDATE media_jobs SET status = 'QUEUED', updated_at = NOW() WHERE id = $1`, [id]);
+    return;
+  }
+  if (status === 'RUNNING') {
+    await pool.query(
+      `UPDATE media_jobs
+       SET status = 'RUNNING', attempts = attempts + 1, started_at = NOW(), updated_at = NOW()
+       WHERE id = $1`,
+      [id]
+    );
+    return;
+  }
+  await pool.query(
+    `UPDATE media_jobs
+     SET status = $2, error = $3, finished_at = NOW(), updated_at = NOW()
+     WHERE id = $1`,
+    [id, status, error ?? null]
+  );
+}
+
+async function runMediaJob(data: MediaJobData, kind: string): Promise<void> {
+  await markJob(data.mediaJobId, 'RUNNING');
+  try {
+    if (kind === 'PROBE_MEDIA') {
+      await probeMedia(data.versionId);
+    } else if (kind === 'EXTRACT_AUDIO') {
+      await extractAudio(data.versionId);
+    } else if (kind === 'TRANSCRIBE') {
+      await transcribe(data.versionId, (data.payload as { language?: string; transcriptId?: string } | null) ?? null);
+    } else {
+      throw new Error(`Unknown job kind ${kind}`);
+    }
+    await markJob(data.mediaJobId, 'SUCCEEDED');
+    console.log(`job ${data.mediaJobId} ${kind} succeeded`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await markJob(data.mediaJobId, 'FAILED', message);
+    console.error(`job ${data.mediaJobId} failed: ${message}`);
+    throw error;
+  }
+}
+
+async function publishPending(boss: PgBoss): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await client.query(
+      `SELECT id, kind, version_id, payload
+       FROM media_jobs
+       WHERE status = 'PENDING'
+       ORDER BY created_at ASC
+       FOR UPDATE SKIP LOCKED
+       LIMIT 20`
+    );
+    for (const row of result.rows) {
+      await client.query(`UPDATE media_jobs SET status = 'QUEUED', updated_at = NOW() WHERE id = $1`, [row.id]);
+    }
+    await client.query('COMMIT');
+    for (const row of result.rows) {
+      try {
+        await boss.send(queueForKind(row.kind), {
+          mediaJobId: row.id,
+          versionId: row.version_id,
+          payload: row.payload,
+        } satisfies MediaJobData);
+      } catch (error) {
+        await pool.query(
+          `UPDATE media_jobs SET status = 'PENDING', updated_at = NOW() WHERE id = $1 AND status = 'QUEUED'`,
+          [row.id]
+        );
+        throw error;
+      }
+    }
+  } catch (error) {
+    try {
+      await client.query('ROLLBACK');
+    } catch {
+      // already committed
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function start(): Promise<void> {
+  if (!process.env.DATABASE_URL) {
+    throw new Error('DATABASE_URL is required');
+  }
+  await mkdir(tmpdir(), { recursive: true });
+
+  const boss = new PgBoss({ connectionString: process.env.DATABASE_URL });
+  boss.on('error', (error) => {
+    console.error('pg-boss error', error);
+  });
+  await boss.start();
+
+  for (const name of Object.values(QUEUE)) {
+    await boss.createQueue(name);
+  }
+
+  await boss.work(QUEUE.PROBE_MEDIA, async (jobs) => {
+    for (const job of jobs) {
+      await runMediaJob(job.data as MediaJobData, 'PROBE_MEDIA');
+    }
+  });
+  await boss.work(QUEUE.EXTRACT_AUDIO, async (jobs) => {
+    for (const job of jobs) {
+      await runMediaJob(job.data as MediaJobData, 'EXTRACT_AUDIO');
+    }
+  });
+  await boss.work(QUEUE.TRANSCRIBE, async (jobs) => {
+    for (const job of jobs) {
+      await runMediaJob(job.data as MediaJobData, 'TRANSCRIBE');
+    }
+  });
+
+  console.log('media worker started (pg-boss)');
+  for (;;) {
+    try {
+      await publishPending(boss);
+    } catch (error) {
+      console.error('worker publish error', error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+}
+
+void start();

--- a/worker/whisper_local.py
+++ b/worker/whisper_local.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""faster-whisper CLI used by the media worker. Prints JSON to stdout."""
+
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: whisper_local.py <audio-path> [language]", file=sys.stderr)
+        return 2
+
+    audio_path = sys.argv[1]
+    language = sys.argv[2] if len(sys.argv) > 2 else None
+
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError:
+        print("faster-whisper is not installed", file=sys.stderr)
+        return 1
+
+    model_size = "base"
+    model = WhisperModel(model_size, device="cpu", compute_type="int8")
+    segments_iter, info = model.transcribe(
+        audio_path,
+        language=language,
+        word_timestamps=True,
+        vad_filter=True,
+    )
+
+    segments = []
+    for segment in segments_iter:
+        words = []
+        for word in segment.words or []:
+            words.append(
+                {
+                    "start": float(word.start),
+                    "end": float(word.end),
+                    "text": word.word.strip(),
+                }
+            )
+        segments.append(
+            {
+                "start": float(segment.start),
+                "end": float(segment.end),
+                "text": segment.text.strip(),
+                "words": words,
+            }
+        )
+
+    json.dump(
+        {
+            "language": info.language or language or "en",
+            "segments": segments,
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Ship machine auth, persisted timecode, a media worker, interactive transcripts, and EDL/FCPXML export so this fork can replace Frame.io for in-house review.

## Summary

<!-- Explain what changed in this PR. -->

## Why

<!-- Explain the problem this PR solves. -->

## Scope

What areas are affected?

- [ ] API routes
- [ ] Auth / access control
- [ ] Database schema / migration
- [ ] UI / UX
- [ ] Documentation
- [ ] Other

## Before opening PR

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md) and followed repository conventions.
- [ ] I ran `bun run check`.
- [ ] I ran `bun run db:generate` if `prisma/schema.prisma` changed.
- [ ] I manually tested affected flows.
- [ ] PR title follows Conventional Commits (`type(scope): summary`).
- [ ] I used `successResponse` / `apiErrors` for API response changes.
- [ ] I used `auth()` and shared access checks (`checkProjectAccess` / `checkWorkspaceAccess`) where relevant.
- [ ] I updated docs when behavior changed.
- [ ] No secrets or unrelated file changes are included.

Validation notes:

```text
Paste command output or manual test notes here.
```

## Breaking changes

- [ ] No breaking changes
- [ ] This PR introduces a breaking change (describe below)

<!-- If breaking, explain migration path. -->

## Database / migration notes

<!-- If schema changed, summarize migration impact. -->

## Screenshots / examples (if relevant)

<!-- Add screenshots or API request/response examples. -->
